### PR TITLE
support Ad Analytics

### DIFF
--- a/src/datasource.js
+++ b/src/datasource.js
@@ -10,6 +10,7 @@ export class BitmovinAnalyticsDatasource {
   constructor(instanceSettings, $q, backendSrv, templateSrv) {
     this.type = instanceSettings.type;
     this.url = instanceSettings.url;
+    this.isAdAnalytics = instanceSettings.jsonData.isAdAnalytics;
     this.name = instanceSettings.name;
     this.q = $q;
     this.backendSrv = backendSrv;
@@ -77,9 +78,12 @@ export class BitmovinAnalyticsDatasource {
       }
       data['groupBy'] = target.groupBy;
       data['limit'] = Number(target.limit) || undefined;
-
+      var apiRequestUrl = this.url + '/analytics/queries'
+      if(this.isAdAnalytics) {
+        var apiRequestUrl = this.url + '/analytics/ads/queries'
+      }      
       return this.doRequest({
-        url: this.url + '/analytics/queries/' + target.metric,
+        url: apiRequestUrl + '/' + target.metric,
         data: data,
         method: 'POST',
         resultTarget: target.alias || target.refId,

--- a/src/partials/config.html
+++ b/src/partials/config.html
@@ -15,4 +15,10 @@
 		<span class="gf-form-label width-9">Tenant Org Id (Optional)</span>
 		<input class="gf-form-input" type="text"  ng-model='ctrl.current.jsonData.tenantOrgId' optional></input>
 	</div>
+
+	<div class="gf-form max-width-25">
+		<span class="gf-form-label width-9">Ad Analytics</span>
+    <editor-checkbox text="" model="ctrl.current.jsonData.isAdAnalytics" class="gf-form-checkbox" ></editor-checkbox>
+
+	</div>
 </div>


### PR DESCRIPTION
hey there 🤚 

we at krone.at wanted to show the ad related analytics in our grafana dashboard.

and stumbled upon an issue that we couldn't do it with the current datasource plugin.


this PR adds an option to mark the datasource as "ad anayltics"
and changes the endpoint to the one needed for the ad analytics.

# Datasource settings screen
![Bildschirmfoto 2019-06-06 um 10 31 14](https://user-images.githubusercontent.com/2891702/59018470-40eef080-8846-11e9-89ef-64a00470792a.png)


Sample Panels

# Ad Impressions OK vs Error

![Bildschirmfoto 2019-06-06 um 10 16 04](https://user-images.githubusercontent.com/2891702/59017738-91fde500-8844-11e9-8677-28e5c45aef86.png)


# Ad Errors by Type (Table and chart)

![Bildschirmfoto 2019-06-06 um 10 16 12](https://user-images.githubusercontent.com/2891702/59017765-a6da7880-8844-11e9-9be5-ffd77c53d01a.png)







here is the modified sample dashboard, with the above panels included. (NOTE: you'd need to change the `<YOUR LICENSE KEY>`



[bm-ad-grafana1.json.zip](https://github.com/bitmovin/analytics-grafana-datasource/files/3260680/bm-ad-grafana1.json.zip)




let me know what you think about it, and if you want me to change anything.


to use the fork, one could do:

```
grafana-cli --pluginUrl https://github.com/hjanuschka/analytics-grafana-datasource/archive/HJ-build.zip plugins install bitmovin-analytics
```


keep up the good work! 🎉 