### PR TITLE
Interval changes and formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Development
 
-- added Grafana Ad hoc filters
-- added order by interval option in query editor
-- added missing attributes
-- added query option to adjust time range to complete datapoints based on current interval
-- added optional new auto interval calculation to take the 200 datapoint API limit into account
+### Added
+
+- Grafana ad hoc filters
+- order by interval option in query editor
+- missing attributes
+- query option to adjust time range to complete datapoints based on current interval
+- optional new auto interval calculation to take the 200 datapoint API limit into account
 
 ## 0.0.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Grafana ad hoc filters
 - order by interval option in query editor
-- missing attributes
+- missing attributes for `dimension` and `orderBy`
 - query option to adjust time range to complete datapoints based on current interval
-- optional new auto interval calculation to take the 200 datapoint API limit into account
 
 ## 0.0.3
 

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -4,6 +4,7 @@ import { AGGREGATION } from './types/aggregations';
 import { calculateAutoInterval, calculateAutoIntervalFromRange, QUERY_INTERVAL } from './types/intervals';
 import { transform } from './result_transformer';
 import { ResultFormat } from './types/resultFormat';
+import { OPERATOR } from './types/operators';
 
 const getApiRequestUrl = (baseUrl, isAdAnalytics, isMetric) => {
   if (isAdAnalytics === true) {
@@ -13,6 +14,25 @@ const getApiRequestUrl = (baseUrl, isAdAnalytics, isMetric) => {
     return baseUrl + '/analytics/metrics';
   }
   return baseUrl + '/analytics/queries';
+};
+
+const mapMathOperatorToAnalyticsFilterOperator = (operator) => {
+  switch (operator) {
+    case '=':
+      return OPERATOR.EQ;
+    case '!=':
+      return OPERATOR.NE;
+    case '<':
+      return OPERATOR.LT;
+    case '<=':
+      return OPERATOR.LTE;
+    case '>':
+      return OPERATOR.GT;
+    case '>=':
+      return OPERATOR.GTE;
+    default:
+      return operator;
+  }
 };
 
 export class BitmovinAnalyticsDatasource {
@@ -63,22 +83,8 @@ export class BitmovinAnalyticsDatasource {
       const filters = _.map([...target.filter, ...query.adhocFilters], e => {
         let filter = {
           name: (e.name) ? e.name : e.key,
-          operator: e.operator,
+          operator: mapMathOperatorToAnalyticsFilterOperator(e.operator),
           value: this.templateSrv.replace(e.value, options.scopedVars)
-        }
-        switch (filter.operator) {
-          case '=':
-            filter.operator = 'EQ';
-            break;
-          case '!=':
-            filter.operator = 'NE';
-            break;
-          case '<':
-            filter.operator = 'LT';
-            break;
-          case '>':
-            filter.operator = 'GT';
-            break;
         }
         return {
           name: filter.name,

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { convertFilterValueToProperType, ATTRIBUTE, ATTRIBUTE_LIST, AD_ATTRIBUTE_LIST, METRICS_ATTRIBUTE_LIST, ORDERBY_ATTRIBUTES, getAsOptionsList } from './types/queryAttributes';
 import { AGGREGATION } from './types/aggregations';
-import { calculateAutoInterval, calculateAutoIntervalFromRange, QUERY_INTERVAL } from './types/intervals';
+import { calculateAutoInterval, calculateAutoIntervalFromRange, getMomentTimeUnitForQueryInterval, QUERY_INTERVAL } from './types/intervals';
 import { transform } from './result_transformer';
 import { ResultFormat } from './types/resultFormat';
 import { OPERATOR } from './types/operators';
@@ -125,23 +125,10 @@ export class BitmovinAnalyticsDatasource {
           data['interval'] = target.interval === QUERY_INTERVAL.AUTO ? calculateAutoInterval(options.intervalMs) : target.interval;
         }
         if (target.intervalSnapTo === true) {
-          switch (data['interval']) {
-            case QUERY_INTERVAL.MONTH:
-            data['start'] = options.range.from.startOf('month').toISOString();
-            data['end'] = options.range.to.startOf('month').toISOString();
-            break;
-            case QUERY_INTERVAL.DAY:
-            data['start'] = options.range.from.startOf('day').toISOString();
-            data['end'] = options.range.to.startOf('day').toISOString();
-            break;
-            case QUERY_INTERVAL.HOUR:
-            data['start'] = options.range.from.startOf('hour').toISOString();
-            data['end'] = options.range.to.startOf('hour').toISOString();
-            break;
-            case QUERY_INTERVAL.MINUTE:
-            data['start'] = options.range.from.startOf('minute').toISOString();
-            data['end'] = options.range.to.startOf('minute').toISOString();
-            break;
+          const intervalTimeUnit = getMomentTimeUnitForQueryInterval(data['interval']);
+          if (intervalTimeUnit != null) {
+            data['start'] = options.range.from.startOf(intervalTimeUnit).toISOString();
+            data['end'] = options.range.to.startOf(intervalTimeUnit).toISOString();
           }
         }
       }

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -180,8 +180,9 @@ export class BitmovinAnalyticsDatasource {
   }
 
   getTagKeys(options) {
-    if (this.isAdAnalytics)
+    if (this.isAdAnalytics) {
       return Promise.resolve(getAsOptionsList(AD_ATTRIBUTE_LIST));
+    }
     return Promise.resolve(getAsOptionsList(ATTRIBUTE_LIST));
   }
 

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -103,7 +103,7 @@ export class BitmovinAnalyticsDatasource {
 
       let isMetric = METRICS_ATTRIBUTE_LIST.includes(target.dimension);
       let urlAppendix = '';
-      
+
       if (isMetric) {
         urlAppendix = target.dimension;
         data['metric'] = target.dimension
@@ -112,16 +112,16 @@ export class BitmovinAnalyticsDatasource {
         target.dimension = target.dimension || ATTRIBUTE.LICENSE_KEY;
         urlAppendix = target.metric
         data['dimension'] = target.dimension;
-    
-          if (target.metric === 'percentile') {
-            data['percentile'] = target.percentileValue;
-          }
+
+        if (target.metric === 'percentile') {
+          data['percentile'] = target.percentileValue;
+        }
       }
 
       if (target.resultFormat === ResultFormat.TIME_SERIES) {
         if (target.intervalAutoLimit === true) {
           data['interval'] = target.interval === QUERY_INTERVAL.AUTO ? calculateAutoIntervalFromRange(options.range.from.valueOf(), options.range.to.valueOf()) : target.interval;
-        }else{
+        } else {
           data['interval'] = target.interval === QUERY_INTERVAL.AUTO ? calculateAutoInterval(options.intervalMs) : target.interval;
         }
         if (target.intervalSnapTo === true) {
@@ -133,7 +133,7 @@ export class BitmovinAnalyticsDatasource {
         }
       }
       data['groupBy'] = target.groupBy;
-      data['orderBy'].forEach (e => {
+      data['orderBy'].forEach(e => {
         if (e.name == ORDERBY_ATTRIBUTES.INTERVAL) {
           e.name = data['interval'];
         }

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { convertFilterValueToProperType, ATTRIBUTE, ATTRIBUTE_LIST, AD_ATTRIBUTE_LIST, METRICS_ATTRIBUTE_LIST, ORDERBY_ATTRIBUTES, getAsOptionsList } from './types/queryAttributes';
 import { AGGREGATION } from './types/aggregations';
-import { calculateAutoInterval, calculateAutoIntervalFromRange, getMomentTimeUnitForQueryInterval, QUERY_INTERVAL } from './types/intervals';
+import { calculateAutoInterval, getMomentTimeUnitForQueryInterval, QUERY_INTERVAL } from './types/intervals';
 import { transform } from './result_transformer';
 import { ResultFormat } from './types/resultFormat';
 import { OPERATOR } from './types/operators';
@@ -119,11 +119,12 @@ export class BitmovinAnalyticsDatasource {
       }
 
       if (target.resultFormat === ResultFormat.TIME_SERIES) {
-        if (target.intervalAutoLimit === true) {
-          data['interval'] = target.interval === QUERY_INTERVAL.AUTO ? calculateAutoIntervalFromRange(options.range.from.valueOf(), options.range.to.valueOf()) : target.interval;
-        } else {
-          data['interval'] = target.interval === QUERY_INTERVAL.AUTO ? calculateAutoInterval(options.intervalMs) : target.interval;
+        data['interval'] = target.interval;
+        if (target.interval === QUERY_INTERVAL.AUTO) {
+          const intervalMs = options.range.to.valueOf() - options.range.from.valueOf();
+          data['interval'] = calculateAutoInterval(intervalMs);
         }
+
         if (target.intervalSnapTo === true) {
           const intervalTimeUnit = getMomentTimeUnitForQueryInterval(data['interval']);
           if (intervalTimeUnit != null) {

--- a/src/partials/query.editor.html
+++ b/src/partials/query.editor.html
@@ -147,8 +147,6 @@
         </div>
       </div>
 
-      <gf-form-switch class="gf-form" label="Maximum of 200 datapoints (API limit)" ng-hide="ctrl.target.interval !== 'AUTO'" checked="ctrl.target.intervalAutoLimit" on-change="ctrl.refresh()"></gf-form-switch>
-
       <div class="gf-form gf-form--grow">
         <div class="gf-form-label gf-form-label--grow"></div>
       </div>

--- a/src/partials/query.editor.html
+++ b/src/partials/query.editor.html
@@ -1,11 +1,15 @@
 <query-editor-row query-ctrl="ctrl" has-text-edit-mode="true">
-
   <div>
     <div class="gf-form-inline">
       <div class="gf-form">
         <label class="gf-form-label query-keyword width-7">License</label>
         <div class="gf-form-select-wrapper">
-          <select class="gf-form-input gf-size-auto" ng-model="ctrl.target.license" ng-options="l.licenseKey as l.label for l in ctrl.licenses" ng-change="ctrl.refresh()"></select>
+          <select
+            class="gf-form-input gf-size-auto"
+            ng-model="ctrl.target.license"
+            ng-options="l.licenseKey as l.label for l in ctrl.licenses"
+            ng-change="ctrl.refresh()"
+          ></select>
         </div>
       </div>
 
@@ -14,16 +18,34 @@
       </div>
     </div>
 
-    <div class="gf-form-inline" ng-if="!ctrl.isDimensionAMetric(ctrl.target.dimension)">
+    <div
+      class="gf-form-inline"
+      ng-if="!ctrl.isDimensionAMetric(ctrl.target.dimension)"
+    >
       <div class="gf-form">
         <label class="gf-form-label query-keyword width-7">Metric</label>
         <div class="gf-form-select-wrapper">
-          <select class="gf-form-input gf-size-auto" ng-model="ctrl.target.metric" ng-options="m for m in ctrl.metrics" ng-change="ctrl.refresh()"></select>
+          <select
+            class="gf-form-input gf-size-auto"
+            ng-model="ctrl.target.metric"
+            ng-options="m for m in ctrl.metrics"
+            ng-change="ctrl.refresh()"
+          ></select>
         </div>
       </div>
 
-      <div class="gf-form max-width-30" ng-if="ctrl.target.metric === 'percentile'">
-        <input type="number" class="gf-form-input" ng-model="ctrl.target.percentileValue" spellcheck='false' placeholder="Naming pattern" ng-blur="ctrl.refresh()">
+      <div
+        class="gf-form max-width-30"
+        ng-if="ctrl.target.metric === 'percentile'"
+      >
+        <input
+          type="number"
+          class="gf-form-input"
+          ng-model="ctrl.target.percentileValue"
+          spellcheck="false"
+          placeholder="Naming pattern"
+          ng-blur="ctrl.refresh()"
+        />
       </div>
 
       <div class="gf-form gf-form--grow">
@@ -35,7 +57,12 @@
       <div class="gf-form">
         <label class="gf-form-label query-keyword width-7">Dimension</label>
         <div class="gf-form-select-wrapper">
-          <select class="gf-form-input gf-size-auto" ng-model="ctrl.target.dimension" ng-options="f for f in ctrl.fields" ng-change="ctrl.refresh()"></select>
+          <select
+            class="gf-form-input gf-size-auto"
+            ng-model="ctrl.target.dimension"
+            ng-options="f for f in ctrl.fields"
+            ng-change="ctrl.refresh()"
+          ></select>
         </div>
       </div>
 
@@ -56,14 +83,30 @@
               <span>And</span>
             </label>
           </div>
-          <metric-segment segment="segment" get-options="ctrl.getFilterSegmentOptions()" on-change="ctrl.filterSegmentUpdate(segment, $index)"></metric-segment>
-          <metric-segment segment="segment.operator" get-options="ctrl.getFilterOperatorOptions()" on-change="ctrl.filterOperatorSegmentUpdate(segment, $index)"></metric-segment>
-          <metric-segment segment="segment.filterValue" get-options="ctrl.getFilterValueOptions(segment, $index)" on-change="ctrl.filterValueSegmentUpdate(segment, $index)"></metric-segment>
+          <metric-segment
+            segment="segment"
+            get-options="ctrl.getFilterSegmentOptions()"
+            on-change="ctrl.filterSegmentUpdate(segment, $index)"
+          ></metric-segment>
+          <metric-segment
+            segment="segment.operator"
+            get-options="ctrl.getFilterOperatorOptions()"
+            on-change="ctrl.filterOperatorSegmentUpdate(segment, $index)"
+          ></metric-segment>
+          <metric-segment
+            segment="segment.filterValue"
+            get-options="ctrl.getFilterValueOptions(segment, $index)"
+            on-change="ctrl.filterValueSegmentUpdate(segment, $index)"
+          ></metric-segment>
         </div>
       </div>
 
       <div class="gf-form">
-        <metric-segment segment="ctrl.filterSegment" get-options="ctrl.getFilterOptions()" on-change="ctrl.filterAction(part, $index)"></metric-segment>
+        <metric-segment
+          segment="ctrl.filterSegment"
+          get-options="ctrl.getFilterOptions()"
+          on-change="ctrl.filterAction(part, $index)"
+        ></metric-segment>
       </div>
 
       <div class="gf-form gf-form--grow">
@@ -75,7 +118,12 @@
       <div class="gf-form">
         <label class="gf-form-label query-keyword width-7">Format As</label>
         <div class="gf-form-select-wrapper">
-          <select class="gf-form-input gf-size-auto" ng-model="ctrl.target.resultFormat" ng-options="rf for rf in ctrl.resultFormats" ng-change="ctrl.refresh()"></select>
+          <select
+            class="gf-form-input gf-size-auto"
+            ng-model="ctrl.target.resultFormat"
+            ng-options="rf for rf in ctrl.resultFormats"
+            ng-change="ctrl.refresh()"
+          ></select>
         </div>
       </div>
       <div class="gf-form gf-form--grow">
@@ -89,14 +137,21 @@
           <span>Group By</span>
         </label>
 
-        <query-part-editor  ng-repeat="part in ctrl.groupByParts"
-                            part="part" class="gf-form-label query-part"
-                            handle-event="ctrl.handleGroupByPartEvent(part, $index, $event)">
+        <query-part-editor
+          ng-repeat="part in ctrl.groupByParts"
+          part="part"
+          class="gf-form-label query-part"
+          handle-event="ctrl.handleGroupByPartEvent(part, $index, $event)"
+        >
         </query-part-editor>
       </div>
 
       <div class="gf-form">
-        <metric-segment segment="ctrl.groupBySegment" get-options="ctrl.getGroupByOptions()" on-change="ctrl.groupByAction(part, $index)"></metric-segment>
+        <metric-segment
+          segment="ctrl.groupBySegment"
+          get-options="ctrl.getGroupByOptions()"
+          on-change="ctrl.groupByAction(part, $index)"
+        ></metric-segment>
       </div>
 
       <div class="gf-form gf-form--grow">
@@ -115,13 +170,25 @@
               <span>And</span>
             </label>
           </div>
-          <metric-segment segment="segment" get-options="ctrl.getOrderByDimensionOptions()" on-change="ctrl.orderByDimensionSegmentUpdate(segment, $index)"></metric-segment>
-          <metric-segment segment="segment.order" get-options="ctrl.getOrderByOperatorOptions()" on-change="ctrl.orderByOrderSegmentUpdate(segment, $index)"></metric-segment>
+          <metric-segment
+            segment="segment"
+            get-options="ctrl.getOrderByDimensionOptions()"
+            on-change="ctrl.orderByDimensionSegmentUpdate(segment, $index)"
+          ></metric-segment>
+          <metric-segment
+            segment="segment.order"
+            get-options="ctrl.getOrderByOperatorOptions()"
+            on-change="ctrl.orderByOrderSegmentUpdate(segment, $index)"
+          ></metric-segment>
         </div>
       </div>
 
       <div class="gf-form">
-        <metric-segment segment="ctrl.orderBySegment" get-options="ctrl.getOrderByDimensionOptions()" on-change="ctrl.orderByAction(part, $index)"></metric-segment>
+        <metric-segment
+          segment="ctrl.orderBySegment"
+          get-options="ctrl.getOrderByDimensionOptions()"
+          on-change="ctrl.orderByAction(part, $index)"
+        ></metric-segment>
       </div>
 
       <div class="gf-form gf-form--grow">
@@ -132,18 +199,33 @@
     <div class="gf-form-inline">
       <div class="gf-form">
         <label class="gf-form-label query-keyword width-7">Limit</label>
-        <input type="text" class="gf-form-input width-9" ng-model="ctrl.target.limit" spellcheck='false' placeholder="No Limit" ng-blur="ctrl.refresh()">
+        <input
+          type="text"
+          class="gf-form-input width-9"
+          ng-model="ctrl.target.limit"
+          spellcheck="false"
+          placeholder="No Limit"
+          ng-blur="ctrl.refresh()"
+        />
       </div>
       <div class="gf-form gf-form--grow">
         <div class="gf-form-label gf-form-label--grow"></div>
       </div>
     </div>
 
-    <div class="gf-form-inline" ng-hide="ctrl.target.resultFormat !== 'time_series'">
+    <div
+      class="gf-form-inline"
+      ng-hide="ctrl.target.resultFormat !== 'time_series'"
+    >
       <div class="gf-form">
         <label class="gf-form-label query-keyword width-7">Interval</label>
         <div class="gf-form-select-wrapper">
-          <select class="gf-form-input gf-size-auto" ng-model="ctrl.target.interval" ng-options="l for l in ctrl.intervals" ng-change="ctrl.refresh()"></select>
+          <select
+            class="gf-form-input gf-size-auto"
+            ng-model="ctrl.target.interval"
+            ng-options="l for l in ctrl.intervals"
+            ng-change="ctrl.refresh()"
+          ></select>
         </div>
       </div>
 
@@ -152,11 +234,19 @@
       </div>
     </div>
 
-    <div class="gf-form-inline" ng-hide="ctrl.target.resultFormat !== 'time_series'">
+    <div
+      class="gf-form-inline"
+      ng-hide="ctrl.target.resultFormat !== 'time_series'"
+    >
       <div class="gf-form">
         <label class="gf-form-label query-keyword width-7">Query options</label>
       </div>
-      <gf-form-switch class="gf-form" label="Adjust time range to complete datapoints" checked="ctrl.target.intervalSnapTo" on-change="ctrl.refresh()"></gf-form-switch>
+      <gf-form-switch
+        class="gf-form"
+        label="Adjust time range to complete datapoints"
+        checked="ctrl.target.intervalSnapTo"
+        on-change="ctrl.refresh()"
+      ></gf-form-switch>
       <div class="gf-form gf-form--grow">
         <div class="gf-form-label gf-form-label--grow"></div>
       </div>
@@ -165,7 +255,14 @@
     <div class="gf-form-inline" ng-hide="ctrl.target.resultFormat === 'table'">
       <div class="gf-form max-width-30">
         <label class="gf-form-label query-keyword width-7">Alias By</label>
-        <input type="text" class="gf-form-input" ng-model="ctrl.target.alias" spellcheck='false' placeholder="Naming pattern" ng-blur="ctrl.refresh()">
+        <input
+          type="text"
+          class="gf-form-input"
+          ng-model="ctrl.target.alias"
+          spellcheck="false"
+          placeholder="Naming pattern"
+          ng-blur="ctrl.refresh()"
+        />
       </div>
       <div class="gf-form gf-form--grow">
         <div class="gf-form-label gf-form-label--grow"></div>
@@ -173,6 +270,8 @@
     </div>
   </div>
   <div class="gf-form" ng-show="ctrl.lastQueryError[ctrl.target.refId]">
-    <pre class="gf-form-pre alert alert-error">{{ctrl.lastQueryError[ctrl.target.refId].data ? ctrl.lastQueryError[ctrl.target.refId].data.data.message : ctrl.lastQueryError[ctrl.target.refId]}}</pre>
+    <pre class="gf-form-pre alert alert-error">
+{{ctrl.lastQueryError[ctrl.target.refId].data ? ctrl.lastQueryError[ctrl.target.refId].data.data.message : ctrl.lastQueryError[ctrl.target.refId]}}</pre
+    >
   </div>
 </query-editor-row>

--- a/src/partials/query.options.html
+++ b/src/partials/query.options.html
@@ -1,4 +1,3 @@
-<section class="grafana-metric-options" >
-  <div class="gf-form">
-  </div>
+<section class="grafana-metric-options">
+  <div class="gf-form"></div>
 </section>

--- a/src/types/intervals.js
+++ b/src/types/intervals.js
@@ -28,11 +28,11 @@ export const getMomentTimeUnitForQueryInterval = (interval) => {
 export const calculateAutoInterval = (intervalMs) => {
   if (intervalMs <= 5 * 1000) { // SECOND granularity for timeframes below 5min
     return QUERY_INTERVAL.SECOND;
-  } else if (intervalMs < 3 * 60 * 60 * 1000) { // MINUTE granularity for timeframes below 3h
+  } else if (intervalMs <= 3 * 60 * 60 * 1000) { // MINUTE granularity for timeframes below 3h
     return QUERY_INTERVAL.MINUTE;
-  } else if (intervalMs < 6 * 24 * 60 * 60 * 1000) { // HOUR granularity for timeframes below 6d
+  } else if (intervalMs <= 6 * 24 * 60 * 60 * 1000) { // HOUR granularity for timeframes below 6d
     return QUERY_INTERVAL.HOUR;
-  } else if (intervalMs < 30 * 24 * 60 * 60 * 1000) { // DAY granularity for timeframes below 30d
+  } else if (intervalMs <= 30 * 24 * 60 * 60 * 1000) { // DAY granularity for timeframes below 30d
     return QUERY_INTERVAL.DAY;
   }
   return QUERY_INTERVAL.MONTH;

--- a/src/types/intervals.js
+++ b/src/types/intervals.js
@@ -9,7 +9,7 @@ export const QUERY_INTERVAL = {
 export const QUERY_INTERVAL_LIST = Object.keys(QUERY_INTERVAL).map(key => QUERY_INTERVAL[key]);
 
 export const getMomentTimeUnitForQueryInterval = (interval) => {
-  switch(interval) {
+  switch (interval) {
     case QUERY_INTERVAL.SECOND:
       return 'second';
     case QUERY_INTERVAL.MINUTE:
@@ -40,7 +40,7 @@ export const calculateAutoInterval = (intervalMs) => {
 }
 
 export const calculateAutoIntervalFromRange = (from, to) => {
-  let dataPointIntervalMs = (to - from)/200;
+  let dataPointIntervalMs = (to - from) / 200;
   if (dataPointIntervalMs <= 1000) {
     return QUERY_INTERVAL.SECOND;
   } else if (dataPointIntervalMs > 1000 && dataPointIntervalMs <= 60000) {

--- a/src/types/intervals.js
+++ b/src/types/intervals.js
@@ -8,6 +8,23 @@ export const QUERY_INTERVAL = {
 };
 export const QUERY_INTERVAL_LIST = Object.keys(QUERY_INTERVAL).map(key => QUERY_INTERVAL[key]);
 
+export const getMomentTimeUnitForQueryInterval = (interval) => {
+  switch(interval) {
+    case QUERY_INTERVAL.SECOND:
+      return 'second';
+    case QUERY_INTERVAL.MINUTE:
+      return 'minute';
+    case QUERY_INTERVAL.HOUR:
+      return 'hour';
+    case QUERY_INTERVAL.DAY:
+      return 'day';
+    case QUERY_INTERVAL.MONTH:
+      return 'month';
+    default:
+      return null;
+  }
+};
+
 export const calculateAutoInterval = (intervalMs) => {
   if (intervalMs <= 1000) {
     return QUERY_INTERVAL.SECOND;

--- a/src/types/intervals.js
+++ b/src/types/intervals.js
@@ -26,30 +26,14 @@ export const getMomentTimeUnitForQueryInterval = (interval) => {
 };
 
 export const calculateAutoInterval = (intervalMs) => {
-  if (intervalMs <= 1000) {
+  if (intervalMs <= 5 * 1000) { // SECOND granularity for timeframes below 5min
     return QUERY_INTERVAL.SECOND;
-  } else if (intervalMs < 60000) {
+  } else if (intervalMs < 3 * 60 * 60 * 1000) { // MINUTE granularity for timeframes below 3h
     return QUERY_INTERVAL.MINUTE;
-  } else if (intervalMs >= 60000 && intervalMs < 604800) {
+  } else if (intervalMs < 6 * 24 * 60 * 60 * 1000) { // HOUR granularity for timeframes below 6d
     return QUERY_INTERVAL.HOUR;
-  } else if (intervalMs >= 604800 && intervalMs < 2592000) {
+  } else if (intervalMs < 30 * 24 * 60 * 60 * 1000) { // DAY granularity for timeframes below 30d
     return QUERY_INTERVAL.DAY;
-  } else {
-    return QUERY_INTERVAL.MONTH;
   }
-}
-
-export const calculateAutoIntervalFromRange = (from, to) => {
-  let dataPointIntervalMs = (to - from) / 200;
-  if (dataPointIntervalMs <= 1000) {
-    return QUERY_INTERVAL.SECOND;
-  } else if (dataPointIntervalMs > 1000 && dataPointIntervalMs <= 60000) {
-    return QUERY_INTERVAL.MINUTE;
-  } else if (dataPointIntervalMs > 60000 && dataPointIntervalMs <= 3600000) {
-    return QUERY_INTERVAL.HOUR;
-  } else if (dataPointIntervalMs > 3600000 && dataPointIntervalMs <= 86400000) {
-    return QUERY_INTERVAL.DAY;
-  } else {
-    return QUERY_INTERVAL.MONTH;
-  }
-}
+  return QUERY_INTERVAL.MONTH;
+};


### PR DESCRIPTION
Adapt changes from #27 and minor improvements:
- adjusted granularities for `AUTO` interval calculation to be in-line with the [bitmovin dashboard](https://bitmovin.com/dashboard/)
- removed toggle for API limit (the API limit of 200 can also be hit with the adjusted interval)
- extended ad-hoc filter mapping of math operators
- formatted HTML files