### PR TITLE
Fixed incorrect URL for testing datasource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Development
 
+### Fixed
+
+- incorrect URL when testing the data source
+
 ## 0.2.0
 
 ### Added

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -171,7 +171,7 @@ export class BitmovinAnalyticsDatasource {
 
   testDatasource() {
     const requestOptions = {
-      url: this.baseURL + '/analytics/licenses',
+      url: this.url + '/analytics/licenses',
       method: 'GET',
     };
     return this.requestHandler.doRequest(requestOptions).then(response => {


### PR DESCRIPTION
Issue: https://bitmovin.atlassian.net/browse/AN-2964
Description: Testing the data source failed due to an incorrect URL. This bug did not affect the functionality of the plugin.