### PR TITLE
feature/AN-3130 bumps grafana version to 6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Development
 
+### Changed
+- bumps grafana version to 6.6
+
 ## 0.2.2
 
 ### Changed

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -18,12 +18,12 @@
       {"name": "Project site", "url": "https://github.com/bitmovin/analytics-grafana-datasource"},
       {"name": "Apache License", "url": "https://github.com/bitmovin/analytics-grafana-datasource/blob/master/LICENSE"}
     ],
-    "version": "0.2.2",
+    "version": "0.3.2",
     "updated": "@@timestamp"
   },
 
   "dependencies": {
-    "grafanaVersion": "4.5.x",
+    "grafanaVersion": "6.6.x",
     "plugins": [ ]
   },
 


### PR DESCRIPTION
This PR bumps the grafana version of the plugin to version 6.6.x.