### PR TITLE
Feat/AN-4041 implement license and interval selection

### DIFF
--- a/bitmovin-analytics-datasource/src/components/QueryEditor.tsx
+++ b/bitmovin-analytics-datasource/src/components/QueryEditor.tsx
@@ -7,14 +7,14 @@ import { MyDataSourceOptions, MyQuery } from '../types';
 import { fetchLicenses } from '../utils/licenses';
 import { DEFAULT_SELECTABLE_QUERY_INTERVAL, SELECTABLE_QUERY_INTERVALS } from '../utils/intervalUtils';
 
-type Props = QueryEditorProps<DataSource, MyQuery, MyDataSourceOptions>;
-
-export enum LoadingState {
+enum LoadingState {
   Default = 'DEFAULT',
   Loading = 'LOADING',
   Success = 'SUCCESS',
   Error = 'ERROR',
 }
+
+type Props = QueryEditorProps<DataSource, MyQuery, MyDataSourceOptions>;
 
 export function QueryEditor({ query, onChange, onRunQuery, datasource }: Props) {
   const [selectableLicenses, setSelectableLicenses] = useState<SelectableValue[]>([]);

--- a/bitmovin-analytics-datasource/src/components/QueryEditor.tsx
+++ b/bitmovin-analytics-datasource/src/components/QueryEditor.tsx
@@ -3,7 +3,7 @@ import { FieldSet, InlineField, InlineSwitch, Select } from '@grafana/ui';
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 
 import { DataSource } from '../datasource';
-import { MyDataSourceOptions, MyQuery } from '../types';
+import { MyDataSourceOptions, BitmovinAnalyticsDataQuery } from '../types';
 import { fetchLicenses } from '../utils/licenses';
 import { DEFAULT_SELECTABLE_QUERY_INTERVAL, SELECTABLE_QUERY_INTERVALS } from '../utils/intervalUtils';
 
@@ -14,7 +14,7 @@ enum LoadingState {
   Error = 'ERROR',
 }
 
-type Props = QueryEditorProps<DataSource, MyQuery, MyDataSourceOptions>;
+type Props = QueryEditorProps<DataSource, BitmovinAnalyticsDataQuery, MyDataSourceOptions>;
 
 export function QueryEditor({ query, onChange, onRunQuery, datasource }: Props) {
   const [selectableLicenses, setSelectableLicenses] = useState<SelectableValue[]>([]);

--- a/bitmovin-analytics-datasource/src/components/QueryEditor.tsx
+++ b/bitmovin-analytics-datasource/src/components/QueryEditor.tsx
@@ -33,7 +33,7 @@ export function QueryEditor({ query, onChange, onRunQuery, datasource }: Props) 
         setLicenseLoadingState(LoadingState.Error);
         setLicenseErrorMessage(e.status + ' ' + e.statusText);
       });
-  }, []);
+  }, [datasource.apiKey, datasource.baseUrl]);
 
   const onLicenseChange = (item: SelectableValue) => {
     onChange({ ...query, licenseKey: item.value });

--- a/bitmovin-analytics-datasource/src/components/QueryEditor.tsx
+++ b/bitmovin-analytics-datasource/src/components/QueryEditor.tsx
@@ -1,32 +1,99 @@
-import React, { ChangeEvent } from 'react';
-import { InlineField, Input } from '@grafana/ui';
-import { QueryEditorProps } from '@grafana/data';
+import React, { ChangeEvent, useEffect, useState } from 'react';
+import { FieldSet, InlineField, InlineSwitch, Select } from '@grafana/ui';
+import { QueryEditorProps, SelectableValue } from '@grafana/data';
+
 import { DataSource } from '../datasource';
 import { MyDataSourceOptions, MyQuery } from '../types';
+import { fetchLicenses } from '../utils/licenses';
+import { DEFAULT_SELECTABLE_QUERY_INTERVAL, SELECTABLE_QUERY_INTERVALS } from '../utils/intervalUtils';
 
 type Props = QueryEditorProps<DataSource, MyQuery, MyDataSourceOptions>;
 
-export function QueryEditor({ query, onChange, onRunQuery }: Props) {
-  const onQueryTextChange = (event: ChangeEvent<HTMLInputElement>) => {
-    onChange({ ...query, queryText: event.target.value });
-  };
+export enum LoadingState {
+  Default = 'DEFAULT',
+  Loading = 'LOADING',
+  Success = 'SUCCESS',
+  Error = 'ERROR',
+}
 
-  const onConstantChange = (event: ChangeEvent<HTMLInputElement>) => {
-    onChange({ ...query, constant: parseFloat(event.target.value) });
-    // executes the query
+export function QueryEditor({ query, onChange, onRunQuery, datasource }: Props) {
+  const [selectableLicenses, setSelectableLicenses] = useState<SelectableValue[]>([]);
+  const [licenseLoadingState, setLicenseLoadingState] = useState<LoadingState>(LoadingState.Default);
+  const [licenseErrorMessage, setLicenseErrorMessage] = useState('');
+  const [isTimeSeries, setIsTimeSeries] = useState(true);
+
+  useEffect(() => {
+    setLicenseLoadingState(LoadingState.Loading);
+    fetchLicenses(datasource.apiKey, datasource.baseUrl)
+      .then((licenses) => {
+        setSelectableLicenses(licenses);
+        setLicenseLoadingState(LoadingState.Success);
+      })
+      .catch((e) => {
+        setLicenseLoadingState(LoadingState.Error);
+        setLicenseErrorMessage(e.status + ' ' + e.statusText);
+      });
+  }, []);
+
+  const onLicenseChange = (item: SelectableValue) => {
+    onChange({ ...query, licenseKey: item.value });
     onRunQuery();
   };
 
-  const { queryText, constant } = query;
+  const onFormatAsTimeSeriesChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setIsTimeSeries(event.currentTarget.checked);
+    if (event.currentTarget.checked) {
+      onChange({ ...query, interval: 'AUTO' });
+    } else {
+      onChange({ ...query, interval: undefined });
+    }
+    onRunQuery();
+  };
+
+  const onIntervalChange = (item: SelectableValue) => {
+    onChange({ ...query, interval: item.value });
+    onRunQuery();
+  };
+
+  const renderTimeSeriesOption = () => {
+    return (
+      <>
+        <InlineField label="Interval" labelWidth={20}>
+          <Select
+            defaultValue={DEFAULT_SELECTABLE_QUERY_INTERVAL}
+            onChange={(item) => onIntervalChange(item)}
+            width={40}
+            options={SELECTABLE_QUERY_INTERVALS}
+          />
+        </InlineField>
+      </>
+    );
+  };
 
   return (
     <div className="gf-form">
-      <InlineField label="Constant">
-        <Input onChange={onConstantChange} value={constant} width={8} type="number" step="0.1" />
-      </InlineField>
-      <InlineField label="Query Text" labelWidth={16} tooltip="Not used yet">
-        <Input onChange={onQueryTextChange} value={queryText || ''} />
-      </InlineField>
+      <FieldSet>
+        <InlineField
+          label="License"
+          labelWidth={20}
+          invalid={licenseLoadingState === LoadingState.Error}
+          error={`Error when fetching Analytics Licenses: ${licenseErrorMessage}`}
+          disabled={licenseLoadingState === LoadingState.Error}
+        >
+          <Select
+            onChange={onLicenseChange}
+            width={40}
+            options={selectableLicenses}
+            noOptionsMessage="No Analytics Licenses found"
+            isLoading={licenseLoadingState === LoadingState.Loading}
+            placeholder={licenseLoadingState === LoadingState.Loading ? 'Loading Licenses' : 'Choose License'}
+          />
+        </InlineField>
+        <InlineField label="Format as time series" labelWidth={20}>
+          <InlineSwitch value={isTimeSeries} onChange={onFormatAsTimeSeriesChange}></InlineSwitch>
+        </InlineField>
+        {isTimeSeries && renderTimeSeriesOption()}
+      </FieldSet>
     </div>
   );
 }

--- a/bitmovin-analytics-datasource/src/datasource.ts
+++ b/bitmovin-analytics-datasource/src/datasource.ts
@@ -9,7 +9,7 @@ import {
 import { getBackendSrv } from '@grafana/runtime';
 import { catchError, lastValueFrom, map, Observable, of } from 'rxjs';
 
-import { MixedDataRowList, MyDataSourceOptions, MyQuery, NumberDataRowList } from './types';
+import { MixedDataRowList, MyDataSourceOptions, BitmovinAnalyticsDataQuery, NumberDataRowList } from './types';
 import { transformGroupedTimeSeriesData, transformSimpleTimeSeries, transformTableData } from './utils/dataUtils';
 import { calculateQueryInterval, QueryInterval } from './utils/intervalUtils';
 
@@ -24,7 +24,7 @@ type AnalyticsQuery = {
   interval?: QueryInterval;
 };
 
-export class DataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> {
+export class DataSource extends DataSourceApi<BitmovinAnalyticsDataQuery, MyDataSourceOptions> {
   baseUrl: string;
   apiKey: string;
   tenantOrgId?: string;
@@ -48,7 +48,7 @@ export class DataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> {
    *      - Interval is not set: All values up to the last one (not included) can be considered string values
    * - The last value of each row is always be a number.
    * */
-  async query(options: DataQueryRequest<MyQuery>): Promise<DataQueryResponse> {
+  async query(options: DataQueryRequest<BitmovinAnalyticsDataQuery>): Promise<DataQueryResponse> {
     const { range } = options;
     const from = range!.from.toDate();
     const to = range!.to.toDate();

--- a/bitmovin-analytics-datasource/src/module.ts
+++ b/bitmovin-analytics-datasource/src/module.ts
@@ -2,8 +2,8 @@ import { DataSourcePlugin } from '@grafana/data';
 import { DataSource } from './datasource';
 import { ConfigEditor } from './components/ConfigEditor';
 import { QueryEditor } from './components/QueryEditor';
-import { MyQuery, MyDataSourceOptions } from './types';
+import { BitmovinAnalyticsDataQuery, MyDataSourceOptions } from './types';
 
-export const plugin = new DataSourcePlugin<DataSource, MyQuery, MyDataSourceOptions>(DataSource)
+export const plugin = new DataSourcePlugin<DataSource, BitmovinAnalyticsDataQuery, MyDataSourceOptions>(DataSource)
   .setConfigEditor(ConfigEditor)
   .setQueryEditor(QueryEditor);

--- a/bitmovin-analytics-datasource/src/types.ts
+++ b/bitmovin-analytics-datasource/src/types.ts
@@ -2,12 +2,12 @@ import { DataSourceJsonData } from '@grafana/data';
 import { DataQuery } from '@grafana/schema';
 import { QueryInterval } from './utils/intervalUtils';
 
-export interface MyQuery extends DataQuery {
+export interface BitmovinAnalyticsDataQuery extends DataQuery {
   licenseKey: string;
   interval?: QueryInterval | 'AUTO';
 }
 
-export const DEFAULT_QUERY: Partial<MyQuery> = {};
+export const DEFAULT_QUERY: Partial<BitmovinAnalyticsDataQuery> = {};
 
 /**
  * These are options configured for each DataSource instance

--- a/bitmovin-analytics-datasource/src/types.ts
+++ b/bitmovin-analytics-datasource/src/types.ts
@@ -1,14 +1,13 @@
 import { DataSourceJsonData } from '@grafana/data';
 import { DataQuery } from '@grafana/schema';
+import { QueryInterval } from './utils/intervalUtils';
 
 export interface MyQuery extends DataQuery {
-  queryText?: string;
-  constant: number;
+  licenseKey: string;
+  interval?: QueryInterval | 'AUTO';
 }
 
-export const DEFAULT_QUERY: Partial<MyQuery> = {
-  constant: 6.5,
-};
+export const DEFAULT_QUERY: Partial<MyQuery> = {};
 
 /**
  * These are options configured for each DataSource instance

--- a/bitmovin-analytics-datasource/src/utils/dataUtils.test.ts
+++ b/bitmovin-analytics-datasource/src/utils/dataUtils.test.ts
@@ -7,14 +7,15 @@ import {
 import { FieldType } from '@grafana/data';
 
 describe('padAndSortTimeSeries', () => {
-  it('should return sorted and padded data for simple time series data', () => {
+  it('should return sorted and padded data for simple time series data for MINUTE interval', () => {
     //arrange
     const data = [
+      [1712919540000, 1], //Friday, 12 April 2024 10:59:00
       [1712919600000, 2], //Friday, 12 April 2024 11:00:00
       [1712919720000, 5], //Friday, 12 April 2024 11:02:00
     ];
 
-    const startTimestamp = 1712919540000; //Friday, 12 April 2024 10:59:00
+    const startTimestamp = 1712919560000; //Friday, 12 April 2024 10:59:20
     const endTimestamp = 1712919780000; //Friday, 12 April 2024 11:03:00
 
     //act
@@ -22,7 +23,6 @@ describe('padAndSortTimeSeries', () => {
 
     //assert
     expect(result).toEqual([
-      [1712919540000, 0],
       [1712919600000, 2],
       [1712919660000, 0],
       [1712919720000, 5],
@@ -30,14 +30,64 @@ describe('padAndSortTimeSeries', () => {
     ]);
   });
 
-  it('should return sorted and padded data for grouped time series data', () => {
+  it('should return sorted and padded data for simple time series data for HOUR Interval', () => {
     //arrange
     const data = [
+      [1712916000000, 1], //Friday, 12 April 2024 10:00:00
+      [1712919600000, 7], //Friday, 12 April 2024 11:00:00
+      [1712930400000, 5], //Friday, 12 April 2024 14:00:00
+      [1712934000000, 2], //Friday, 12 April 2024 15:00:00
+    ];
+
+    const startTimestamp = 1712917444000; //Friday, 12 April 2024 10:24:04
+    const endTimestamp = 1712935444000; //Friday, 12 April 2024 15:24:04
+
+    //act
+    const result = padAndSortTimeSeries(data, startTimestamp, endTimestamp, 'HOUR');
+
+    //assert
+    expect(result).toEqual([
+      [1712919600000, 7], //Friday, 12 April 2024 11:00:00
+      [1712923200000, 0], //Friday, 12 April 2024 12:00:00
+      [1712926800000, 0], //Friday, 12 April 2024 13:00:00
+      [1712930400000, 5], //Friday, 12 April 2024 14:00:00
+      [1712934000000, 2], //Friday, 12 April 2024 15:00:00
+    ]);
+  });
+
+  it('should return sorted and padded data for simple time series data for DAY interval', () => {
+    //arrange
+    const data = [
+      [1712917800000, 1], //Friday, 12 April 2024 10:30:00
+      [1713004200000, 2], //Saturday, 13 April 2024 10:30:00
+      [1713263400000, 5], //Tuesday, 16 April 2024 10:30:00
+    ];
+
+    const startTimestamp = 1712919560000; //Friday, 12 April 2024 10:59:20
+    const endTimestamp = 1713351560000; //Wednesday, 17 April 2024 10:59:20
+
+    //act
+    const result = padAndSortTimeSeries(data, startTimestamp, endTimestamp, 'DAY');
+
+    //assert
+    expect(result).toEqual([
+      [1713004200000, 2], //Saturday, 13 April 2024 10:30:00
+      [1713090600000, 0], //Sunday, 14 April 2024 10:30:00
+      [1713177000000, 0], //Monday, 15 April 2024 10:30:00
+      [1713263400000, 5], //Tuesday, 16 April 2024 10:30:00
+      [1713349800000, 0], //Wednesday, 17 April 2024 10:30:00
+    ]);
+  });
+
+  it('should return sorted and padded data for grouped time series data for MINUTE interval', () => {
+    //arrange
+    const data = [
+      [1712919540000, 'BROWSER', 'DEVICE_TYPE', 1], //Friday, 12 April 2024 10:59:00
       [1712919600000, 'BROWSER', 'DEVICE_TYPE', 2], //Friday, 12 April 2024 11:00:00
       [1712919720000, 'BROWSER', 'DEVICE_TYPE', 5], //Friday, 12 April 2024 11:02:00
     ];
 
-    const startTimestamp = 1712919540000; //Friday, 12 April 2024 10:59:00
+    const startTimestamp = 1712919560000; //Friday, 12 April 2024 10:59:20
     const endTimestamp = 1712919780000; //Friday, 12 April 2024 11:03:00
 
     //act
@@ -45,11 +95,59 @@ describe('padAndSortTimeSeries', () => {
 
     //assert
     expect(result).toEqual([
-      [1712919540000, 'BROWSER', 'DEVICE_TYPE', 0],
       [1712919600000, 'BROWSER', 'DEVICE_TYPE', 2],
       [1712919660000, 'BROWSER', 'DEVICE_TYPE', 0],
       [1712919720000, 'BROWSER', 'DEVICE_TYPE', 5],
       [1712919780000, 'BROWSER', 'DEVICE_TYPE', 0],
+    ]);
+  });
+
+  it('should return sorted and padded data for grouped time series data for HOUR interval', () => {
+    //arrange
+    const data = [
+      [1712916000000, 'BROWSER', 'DEVICE_TYPE', 1], //Friday, 12 April 2024 10:00:00
+      [1712919600000, 'BROWSER', 'DEVICE_TYPE', 7], //Friday, 12 April 2024 11:00:00
+      [1712930400000, 'BROWSER', 'DEVICE_TYPE', 5], //Friday, 12 April 2024 14:00:00
+      [1712934000000, 'BROWSER', 'DEVICE_TYPE', 2], //Friday, 12 April 2024 15:00:00
+    ];
+
+    const startTimestamp = 1712917444000; //Friday, 12 April 2024 10:24:04
+    const endTimestamp = 1712935444000; //Friday, 12 April 2024 15:24:04
+
+    //act
+    const result = padAndSortTimeSeries(data, startTimestamp, endTimestamp, 'HOUR');
+
+    //assert
+    expect(result).toEqual([
+      [1712919600000, 'BROWSER', 'DEVICE_TYPE', 7], //Friday, 12 April 2024 11:00:00
+      [1712923200000, 'BROWSER', 'DEVICE_TYPE', 0], //Friday, 12 April 2024 12:00:00
+      [1712926800000, 'BROWSER', 'DEVICE_TYPE', 0], //Friday, 12 April 2024 13:00:00
+      [1712930400000, 'BROWSER', 'DEVICE_TYPE', 5], //Friday, 12 April 2024 14:00:00
+      [1712934000000, 'BROWSER', 'DEVICE_TYPE', 2], //Friday, 12 April 2024 15:00:00
+    ]);
+  });
+
+  it('should return sorted and padded data for grouped time series data for DAY interval', () => {
+    //arrange
+    const data = [
+      [1712917800000, 'BROWSER', 'DEVICE_TYPE', 1], //Friday, 12 April 2024 10:30:00
+      [1713004200000, 'BROWSER', 'DEVICE_TYPE', 2], //Saturday, 13 April 2024 10:30:00
+      [1713263400000, 'BROWSER', 'DEVICE_TYPE', 5], //Tuesday, 16 April 2024 10:30:00
+    ];
+
+    const startTimestamp = 1712919560000; //Friday, 12 April 2024 10:59:20
+    const endTimestamp = 1713351560000; //Wednesday, 17 April 2024 10:59:20
+
+    //act
+    const result = padAndSortTimeSeries(data, startTimestamp, endTimestamp, 'DAY');
+
+    //assert
+    expect(result).toEqual([
+      [1713004200000, 'BROWSER', 'DEVICE_TYPE', 2], //Saturday, 13 April 2024 10:30:00
+      [1713090600000, 'BROWSER', 'DEVICE_TYPE', 0], //Sunday, 14 April 2024 10:30:00
+      [1713177000000, 'BROWSER', 'DEVICE_TYPE', 0], //Monday, 15 April 2024 10:30:00
+      [1713263400000, 'BROWSER', 'DEVICE_TYPE', 5], //Tuesday, 16 April 2024 10:30:00
+      [1713349800000, 'BROWSER', 'DEVICE_TYPE', 0], //Wednesday, 17 April 2024 10:30:00
     ]);
   });
 

--- a/bitmovin-analytics-datasource/src/utils/intervalUtils.test.ts
+++ b/bitmovin-analytics-datasource/src/utils/intervalUtils.test.ts
@@ -52,93 +52,119 @@ describe('calculateQueryInterval', () => {
 });
 
 describe('ceilTimestampAccordingToQueryInterval', () => {
-  it('should return same timestamp for already rounded MINUTE interval timestamp ', () => {
+  it('should return same timestamp for already rounded MINUTE interval start timestamp ', () => {
     //arrange
-    const timestamp = 1713513900000; //Friday, 19 April 2024 08:05:00
+    const startTimestamp = 1713513900000; //Friday, 19 April 2024 08:05:00
 
     //act
-    const result = ceilTimestampAccordingToQueryInterval(timestamp, 'MINUTE', 0);
+    const result = ceilTimestampAccordingToQueryInterval(startTimestamp, 'MINUTE', 0);
 
     //assert
-    expect(result).toEqual(timestamp);
+    expect(result).toEqual(startTimestamp);
   });
 
-  it('should return ceiled timestamp for MINUTE interval timestamp with milliseconds != 0', () => {
+  it('should return ceiled timestamp for MINUTE interval and start timestamp with milliseconds != 0', () => {
     //arrange
-    const timestamp = 1713513900100; //Friday, 19 April 2024 08:05:00.100
+    const startTimestamp = 1713513900100; //Friday, 19 April 2024 08:05:00.100
     const expectedTimestamp = 1713513960000; //Friday, 19 April 2024 08:06:00
 
     //act
-    const result = ceilTimestampAccordingToQueryInterval(timestamp, 'MINUTE', 0);
+    const result = ceilTimestampAccordingToQueryInterval(startTimestamp, 'MINUTE', 0);
 
     //assert
     expect(result).toEqual(expectedTimestamp);
   });
 
-  it('should return ceiled timestamp for MINUTE interval timestamp with seconds != 0', () => {
+  it('should return ceiled timestamp for MINUTE interval and start timestamp with seconds != 0', () => {
     //arrange
-    const timestamp = 1713513912000; //Friday, 19 April 2024 08:05:12
+    const startTimestamp = 1713513912000; //Friday, 19 April 2024 08:05:12
     const expectedTimestamp = 1713513960000; //Friday, 19 April 2024 08:06:00
 
     //act
-    const result = ceilTimestampAccordingToQueryInterval(timestamp, 'MINUTE', 0);
+    const result = ceilTimestampAccordingToQueryInterval(startTimestamp, 'MINUTE', 0);
 
     //assert
     expect(result).toEqual(expectedTimestamp);
   });
 
-  it('should return same timestamp for already rounded HOUR interval timestamp ', () => {
+  it('should return same timestamp for already rounded HOUR interval start timestamp ', () => {
     //arrange
-    const timestamp = 1713513600000; //Friday, 19 April 2024 08:00:00
+    const startTimestamp = 1713513600000; //Friday, 19 April 2024 08:00:00
 
     //act
-    const result = ceilTimestampAccordingToQueryInterval(timestamp, 'HOUR', 0);
+    const result = ceilTimestampAccordingToQueryInterval(startTimestamp, 'HOUR', 0);
 
     //assert
-    expect(result).toEqual(timestamp);
+    expect(result).toEqual(startTimestamp);
   });
 
-  it('should return ceiled timestamp for HOUR interval timestamp with milliseconds != 0', () => {
+  it('should return ceiled timestamp for HOUR interval and start timestamp with milliseconds != 0', () => {
     //arrange
-    const timestamp = 1713513600100; //Friday, 19 April 2024 08:00:00.100
+    const startTimestamp = 1713513600100; //Friday, 19 April 2024 08:00:00.100
     const expectedTimestamp = 1713517200000; //Friday, 19 April 2024 09:00:00
 
     //act
-    const result = ceilTimestampAccordingToQueryInterval(timestamp, 'HOUR', 0);
+    const result = ceilTimestampAccordingToQueryInterval(startTimestamp, 'HOUR', 0);
 
     //assert
     expect(result).toEqual(expectedTimestamp);
   });
 
-  it('should return ceiled timestamp for HOUR interval timestamp with seconds != 0', () => {
+  it('should return ceiled timestamp for HOUR interval and start timestamp with seconds != 0', () => {
     //arrange
-    const timestamp = 1713513612000; //Friday, 19 April 2024 08:00:12
+    const startTimestamp = 1713513612000; //Friday, 19 April 2024 08:00:12
     const expectedTimestamp = 1713517200000; //Friday, 19 April 2024 09:00:00
 
     //act
-    const result = ceilTimestampAccordingToQueryInterval(timestamp, 'HOUR', 0);
+    const result = ceilTimestampAccordingToQueryInterval(startTimestamp, 'HOUR', 0);
 
     //assert
     expect(result).toEqual(expectedTimestamp);
   });
 
-  it('should return ceiled timestamp for HOUR interval timestamp with minutes != 0', () => {
+  it('should return ceiled timestamp for HOUR interval and start timestamp with minutes != 0', () => {
     //arrange
-    const timestamp = 1713514320000; //Friday, 19 April 2024 08:12:00
+    const startTimestamp = 1713514320000; //Friday, 19 April 2024 08:12:00
     const expectedTimestamp = 1713517200000; //Friday, 19 April 2024 09:00:00
 
     //act
-    const result = ceilTimestampAccordingToQueryInterval(timestamp, 'HOUR', 0);
+    const result = ceilTimestampAccordingToQueryInterval(startTimestamp, 'HOUR', 0);
 
     //assert
     expect(result).toEqual(expectedTimestamp);
   });
 
-  it('should return correct timestamp DAY interval timestamp ', () => {
+  it('should return correct timestamp with DAY interval and start timestamp before data timestamp', () => {
     //arrange
-    const timestamp = 1713514320000; //Friday, 19 April 2024 08:12:00
+    const startTimestamp = 1713514320000; //Friday, 19 April 2024 08:12:00
     const dataTimestamp = 1713954600000; //Wednesday, 24 April 2024 10:30:00
     const expectedTimestamp = 1713522600000; //Friday, 19 April 2024 10:30:00
+
+    //act
+    const result = ceilTimestampAccordingToQueryInterval(startTimestamp, 'DAY', dataTimestamp);
+
+    //assert
+    expect(result).toEqual(expectedTimestamp);
+  });
+
+  it('should return ceiled timestamp with DAY interval and start timestamp after data timestamp', () => {
+    //arrange
+    const startTimestamp = 1713522184000; //Friday, 19 April 2024 10:23:04
+    const dataTimestamp = 1713517200000; //Friday, 19 April 2024 09:00:00
+    const expectedTimestamp = 1713603600000; //Saturday, 20 April 2024 09:00:00
+
+    //act
+    const result = ceilTimestampAccordingToQueryInterval(startTimestamp, 'DAY', dataTimestamp);
+
+    //assert
+    expect(result).toEqual(expectedTimestamp);
+  });
+
+  it('should return ceiled timestamp with DAY interval and start timestamp after data timestamp and start timestamp being last day of a month', () => {
+    //arrange
+    const timestamp = 1714474760000; //Tuesday, 30 April 2024 10:59:20
+    const dataTimestamp = 1714467600000; //Tuesday, 30 April 2024 09:00:00
+    const expectedTimestamp = 1714554000000; //Wednesday, 1 May 2024 09:00:00
 
     //act
     const result = ceilTimestampAccordingToQueryInterval(timestamp, 'DAY', dataTimestamp);

--- a/bitmovin-analytics-datasource/src/utils/intervalUtils.test.ts
+++ b/bitmovin-analytics-datasource/src/utils/intervalUtils.test.ts
@@ -1,0 +1,149 @@
+import { calculateQueryInterval, ceilTimestampAccordingToQueryInterval } from './intervalUtils';
+
+describe('calculateQueryInterval', () => {
+  it('should return correct given interval if interval is not AUTO', () => {
+    //arrange
+    const startTimestamp = 1713349080000; //Wednesday, 17 April 2024 10:18:00
+    const endTimestamp = 1713356280000; //Wednesday, 17 April 2024 12:18:00
+    const interval = 'MINUTE';
+
+    // act
+    const result = calculateQueryInterval(interval, startTimestamp, endTimestamp);
+
+    //assert
+    expect(result).toEqual(interval);
+  });
+
+  it('should return MINUTE interval if interval is AUTO and time interval below 3 hours', () => {
+    //arrange
+    const startTimestamp = 1713349080000; //Wednesday, 17 April 2024 10:18:00
+    const endTimestamp = 1713356280000; //Wednesday, 17 April 2024 12:18:00
+
+    // act
+    const result = calculateQueryInterval('AUTO', startTimestamp, endTimestamp);
+
+    //assert
+    expect(result).toEqual('MINUTE');
+  });
+
+  it('should return HOUR interval if interval is AUTO and time interval bigger 3 hours and than below 6 hours', () => {
+    //arrange
+    const startTimestamp = 1713345420000; //Wednesday, 17 April 2024 09:17:00
+    const endTimestamp = 1713356280000; //Wednesday, 17 April 2024 12:18:00
+
+    // act
+    const result = calculateQueryInterval('AUTO', startTimestamp, endTimestamp);
+
+    //assert
+    expect(result).toEqual('HOUR');
+  });
+
+  it('should return DAY interval if interval is AUTO and time interval bigger than 6 days', () => {
+    //arrange
+    const startTimestamp = 1712837820000; //Thursday, 11 April 2024 12:17:00
+    const endTimestamp = 1713356280000; //Wednesday, 17 April 2024 12:18:00
+
+    // act
+    const result = calculateQueryInterval('AUTO', startTimestamp, endTimestamp);
+
+    //assert
+    expect(result).toEqual('DAY');
+  });
+});
+
+describe('ceilTimestampAccordingToQueryInterval', () => {
+  it('should return same timestamp for already rounded MINUTE interval timestamp ', () => {
+    //arrange
+    const timestamp = 1713513900000; //Friday, 19 April 2024 08:05:00
+
+    //act
+    const result = ceilTimestampAccordingToQueryInterval(timestamp, 'MINUTE', 0);
+
+    //assert
+    expect(result).toEqual(timestamp);
+  });
+
+  it('should return ceiled timestamp for MINUTE interval timestamp with milliseconds != 0', () => {
+    //arrange
+    const timestamp = 1713513900100; //Friday, 19 April 2024 08:05:00.100
+    const expectedTimestamp = 1713513960000; //Friday, 19 April 2024 08:06:00
+
+    //act
+    const result = ceilTimestampAccordingToQueryInterval(timestamp, 'MINUTE', 0);
+
+    //assert
+    expect(result).toEqual(expectedTimestamp);
+  });
+
+  it('should return ceiled timestamp for MINUTE interval timestamp with seconds != 0', () => {
+    //arrange
+    const timestamp = 1713513912000; //Friday, 19 April 2024 08:05:12
+    const expectedTimestamp = 1713513960000; //Friday, 19 April 2024 08:06:00
+
+    //act
+    const result = ceilTimestampAccordingToQueryInterval(timestamp, 'MINUTE', 0);
+
+    //assert
+    expect(result).toEqual(expectedTimestamp);
+  });
+
+  it('should return same timestamp for already rounded HOUR interval timestamp ', () => {
+    //arrange
+    const timestamp = 1713513600000; //Friday, 19 April 2024 08:00:00
+
+    //act
+    const result = ceilTimestampAccordingToQueryInterval(timestamp, 'HOUR', 0);
+
+    //assert
+    expect(result).toEqual(timestamp);
+  });
+
+  it('should return ceiled timestamp for HOUR interval timestamp with milliseconds != 0', () => {
+    //arrange
+    const timestamp = 1713513600100; //Friday, 19 April 2024 08:00:00.100
+    const expectedTimestamp = 1713517200000; //Friday, 19 April 2024 09:00:00
+
+    //act
+    const result = ceilTimestampAccordingToQueryInterval(timestamp, 'HOUR', 0);
+
+    //assert
+    expect(result).toEqual(expectedTimestamp);
+  });
+
+  it('should return ceiled timestamp for HOUR interval timestamp with seconds != 0', () => {
+    //arrange
+    const timestamp = 1713513612000; //Friday, 19 April 2024 08:00:12
+    const expectedTimestamp = 1713517200000; //Friday, 19 April 2024 09:00:00
+
+    //act
+    const result = ceilTimestampAccordingToQueryInterval(timestamp, 'HOUR', 0);
+
+    //assert
+    expect(result).toEqual(expectedTimestamp);
+  });
+
+  it('should return ceiled timestamp for HOUR interval timestamp with minutes != 0', () => {
+    //arrange
+    const timestamp = 1713514320000; //Friday, 19 April 2024 08:12:00
+    const expectedTimestamp = 1713517200000; //Friday, 19 April 2024 09:00:00
+
+    //act
+    const result = ceilTimestampAccordingToQueryInterval(timestamp, 'HOUR', 0);
+
+    //assert
+    expect(result).toEqual(expectedTimestamp);
+  });
+
+  it('should return correct timestamp DAY interval timestamp ', () => {
+    //arrange
+    const timestamp = 1713514320000; //Friday, 19 April 2024 08:12:00
+    const dataTimestamp = 1713954600000; //Wednesday, 24 April 2024 10:30:00
+    const expectedTimestamp = 1713522600000; //Friday, 19 April 2024 10:30:00
+
+    //act
+    const result = ceilTimestampAccordingToQueryInterval(timestamp, 'DAY', dataTimestamp);
+
+    //assert
+    expect(result).toEqual(expectedTimestamp);
+  });
+});

--- a/bitmovin-analytics-datasource/src/utils/intervalUtils.ts
+++ b/bitmovin-analytics-datasource/src/utils/intervalUtils.ts
@@ -72,22 +72,33 @@ export function ceilTimestampAccordingToQueryInterval(
   interval: QueryInterval,
   dataTimestamp: number
 ): number {
-  const date = new Date(startTimestamp);
+  const startDate = new Date(startTimestamp);
   switch (interval) {
     case 'MINUTE':
-      if (date.getSeconds() === 0 && date.getMilliseconds() === 0) {
+      if (startDate.getSeconds() === 0 && startDate.getMilliseconds() === 0) {
         return startTimestamp;
       }
-      return date.setMinutes(date.getMinutes() + 1, 0, 0);
+      return startDate.setMinutes(startDate.getMinutes() + 1, 0, 0);
     case 'HOUR':
-      if (date.getMinutes() === 0 && date.getSeconds() === 0 && date.getMilliseconds() === 0) {
+      if (startDate.getMinutes() === 0 && startDate.getSeconds() === 0 && startDate.getMilliseconds() === 0) {
         return startTimestamp;
       }
-      return date.setHours(date.getHours() + 1, 0, 0, 0);
+      return startDate.setHours(startDate.getHours() + 1, 0, 0, 0);
     case 'DAY':
       // Take the hours and minutes value from the datapoint timestamps as the timestamps for the day interval depend on the timezone of the license
       const dataHours = new Date(dataTimestamp).getHours();
       const dataMinutes = new Date(dataTimestamp).getMinutes();
-      return new Date(date.getFullYear(), date.getMonth(), date.getDate(), dataHours, dataMinutes).getTime();
+      const startDateWithCorrectTime = new Date(
+        startDate.getFullYear(),
+        startDate.getMonth(),
+        startDate.getDate(),
+        dataHours,
+        dataMinutes
+      );
+
+      if (startDateWithCorrectTime.getTime() > startTimestamp) {
+        return startDateWithCorrectTime.getTime();
+      }
+      return new Date(startDateWithCorrectTime).setDate(startDateWithCorrectTime.getDate() + 1);
   }
 }

--- a/bitmovin-analytics-datasource/src/utils/intervalUtils.ts
+++ b/bitmovin-analytics-datasource/src/utils/intervalUtils.ts
@@ -85,8 +85,9 @@ export function ceilTimestampAccordingToQueryInterval(
       }
       return date.setHours(date.getHours() + 1, 0, 0, 0);
     case 'DAY':
-      // Take the hours value from the datapoint timestamps as the timestamps for the day interval depend on the timezone of the license
+      // Take the hours and minutes value from the datapoint timestamps as the timestamps for the day interval depend on the timezone of the license
       const dataHours = new Date(dataTimestamp).getHours();
-      return new Date(date.getFullYear(), date.getMonth(), date.getDate(), dataHours).getTime();
+      const dataMinutes = new Date(dataTimestamp).getMinutes();
+      return new Date(date.getFullYear(), date.getMonth(), date.getDate(), dataHours, dataMinutes).getTime();
   }
 }

--- a/bitmovin-analytics-datasource/src/utils/intervalUtils.ts
+++ b/bitmovin-analytics-datasource/src/utils/intervalUtils.ts
@@ -1,5 +1,16 @@
 export type QueryInterval = 'MINUTE' | 'HOUR' | 'DAY';
 
+export type SelectableQueryInterval = QueryInterval | 'AUTO';
+
+export const SELECTABLE_QUERY_INTERVALS: Array<{ value: SelectableQueryInterval | 'AUTO'; label: string }> = [
+  { value: 'AUTO', label: 'Auto' },
+  { value: 'MINUTE', label: 'Minute' },
+  { value: 'HOUR', label: 'Hour' },
+  { value: 'DAY', label: 'Day' },
+];
+
+export const DEFAULT_SELECTABLE_QUERY_INTERVAL = SELECTABLE_QUERY_INTERVALS[0];
+
 /**
  * Get corresponding interval in milliseconds.
  *
@@ -18,3 +29,64 @@ export const intervalToMilliseconds = (interval: QueryInterval): number => {
       return -1;
   }
 };
+
+/**
+ * Calculates the Query interval based on a given selected interval, start timestamp and end timestamp
+ *
+ * @param {SelectableQueryInterval} interval The selected interval
+ * @param {number} startTimestamp The start timestamp in milliseconds
+ * @param {number} endTimestamp The end timestamp in milliseconds
+ * @returns {QueryInterval} calculated Interval as QueryInterval
+ */
+export const calculateQueryInterval = (
+  interval: SelectableQueryInterval,
+  startTimestamp: number,
+  endTimestamp: number
+): QueryInterval => {
+  if (interval !== 'AUTO') {
+    return interval as QueryInterval;
+  }
+
+  const intervalInMilliseconds = endTimestamp - startTimestamp;
+  const minuteIntervalLimitInMilliseconds = 3 * 60 * 60 * 1000; // MINUTE granularity for timeframes below 3h
+  const hourIntervalLimitInMilliseconds = 6 * 24 * 60 * 60 * 1000; // HOUR granularity for timeframes below 6d
+
+  if (intervalInMilliseconds <= minuteIntervalLimitInMilliseconds) {
+    return 'MINUTE';
+  } else if (intervalInMilliseconds <= hourIntervalLimitInMilliseconds) {
+    return 'HOUR';
+  }
+  return 'DAY';
+};
+
+/**
+ * Rounds up a timestamp according to the specified query interval.
+ *
+ * @param {number} startTimestamp The start timestamp of the query.
+ * @param {QueryInterval} interval       The query interval.
+ * @param {number} dataTimestamp  The timestamp of a data point. Needed to calculate correct Day interval timestamp.
+ * @return {number} The rounded up timestamp.
+ */
+export function ceilTimestampAccordingToQueryInterval(
+  startTimestamp: number,
+  interval: QueryInterval,
+  dataTimestamp: number
+): number {
+  const date = new Date(startTimestamp);
+  switch (interval) {
+    case 'MINUTE':
+      if (date.getSeconds() === 0 && date.getMilliseconds() === 0) {
+        return startTimestamp;
+      }
+      return date.setMinutes(date.getMinutes() + 1, 0, 0);
+    case 'HOUR':
+      if (date.getMinutes() === 0 && date.getSeconds() === 0 && date.getMilliseconds() === 0) {
+        return startTimestamp;
+      }
+      return date.setHours(date.getHours() + 1, 0, 0, 0);
+    case 'DAY':
+      // Take the hours value from the datapoint timestamps as the timestamps for the day interval depend on the timezone of the license
+      const dataHours = new Date(dataTimestamp).getHours();
+      return new Date(date.getFullYear(), date.getMonth(), date.getDate(), dataHours).getTime();
+  }
+}

--- a/bitmovin-analytics-datasource/src/utils/licenses.ts
+++ b/bitmovin-analytics-datasource/src/utils/licenses.ts
@@ -2,31 +2,41 @@ import { lastValueFrom } from 'rxjs';
 import { getBackendSrv } from '@grafana/runtime';
 import { SelectableValue } from '@grafana/data';
 
+type AnalyticsLicense = {
+  readonly name: string;
+  readonly id: string;
+  readonly licenseKey?: string;
+};
+
 const licenseEndpoints = [
   {
     endpoint: '/analytics/licenses',
-    mapperFunc: (license: any): SelectableValue => ({
+    mapperFunc: (license: AnalyticsLicense): SelectableValue => ({
       value: license.licenseKey,
       label: license.name ? license.name : license.licenseKey,
     }),
   },
   {
     endpoint: '/analytics/virtual-licenses',
-    mapperFunc: (license: any): SelectableValue => ({
+    mapperFunc: (license: AnalyticsLicense): SelectableValue => ({
       value: license.id,
       label: license.name ? license.name : license.id,
     }),
   },
   {
     endpoint: '/analytics/demo-licenses',
-    mapperFunc: (license: any): SelectableValue => ({
+    mapperFunc: (license: AnalyticsLicense): SelectableValue => ({
       value: license.id,
       label: license.name ? license.name : license.id,
     }),
   },
 ];
 
-async function fetchLicensesForEndpoint(url: string, apiKey: string, mapperFunc: (license: any) => SelectableValue) {
+async function fetchLicensesForEndpoint(
+  url: string,
+  apiKey: string,
+  mapperFunc: (license: AnalyticsLicense) => SelectableValue
+) {
   const options = {
     url: url,
     headers: { 'X-Api-Key': apiKey },
@@ -48,11 +58,11 @@ async function fetchLicensesForEndpoint(url: string, apiKey: string, mapperFunc:
 export async function fetchLicenses(apiKey: string, baseUrl: string): Promise<SelectableValue[]> {
   const allLicenses: SelectableValue[] = [];
 
-  for (const licenseEndpoints1 of licenseEndpoints) {
+  for (const licenseEndpoint of licenseEndpoints) {
     const licenses = await fetchLicensesForEndpoint(
-      baseUrl + licenseEndpoints1.endpoint,
+      baseUrl + licenseEndpoint.endpoint,
       apiKey,
-      licenseEndpoints1.mapperFunc
+      licenseEndpoint.mapperFunc
     );
     allLicenses.push(...licenses);
   }

--- a/bitmovin-analytics-datasource/src/utils/licenses.ts
+++ b/bitmovin-analytics-datasource/src/utils/licenses.ts
@@ -1,0 +1,61 @@
+import { lastValueFrom } from 'rxjs';
+import { getBackendSrv } from '@grafana/runtime';
+import { SelectableValue } from '@grafana/data';
+
+const licenseEndpoints = [
+  {
+    endpoint: '/analytics/licenses',
+    mapperFunc: (license: any): SelectableValue => ({
+      value: license.licenseKey,
+      label: license.name ? license.name : license.licenseKey,
+    }),
+  },
+  {
+    endpoint: '/analytics/virtual-licenses',
+    mapperFunc: (license: any): SelectableValue => ({
+      value: license.id,
+      label: license.name ? license.name : license.id,
+    }),
+  },
+  {
+    endpoint: '/analytics/demo-licenses',
+    mapperFunc: (license: any): SelectableValue => ({
+      value: license.id,
+      label: license.name ? license.name : license.id,
+    }),
+  },
+];
+
+async function fetchLicensesForEndpoint(url: string, apiKey: string, mapperFunc: (license: any) => SelectableValue) {
+  const options = {
+    url: url,
+    headers: { 'X-Api-Key': apiKey },
+    method: 'GET',
+  };
+
+  const response = await lastValueFrom(getBackendSrv().fetch(options));
+  // @ts-ignore
+  const licenses = response.data.data.result.items;
+
+  const selectableLicenses = [];
+  for (const license of licenses) {
+    selectableLicenses.push(mapperFunc(license));
+  }
+
+  return selectableLicenses;
+}
+
+export async function fetchLicenses(apiKey: string, baseUrl: string): Promise<SelectableValue[]> {
+  const allLicenses: SelectableValue[] = [];
+
+  for (const licenseEndpoints1 of licenseEndpoints) {
+    const licenses = await fetchLicensesForEndpoint(
+      baseUrl + licenseEndpoints1.endpoint,
+      apiKey,
+      licenseEndpoints1.mapperFunc
+    );
+    allLicenses.push(...licenses);
+  }
+
+  return allLicenses;
+}


### PR DESCRIPTION
Issue: https://bitmovin.atlassian.net/browse/AN-4041, https://bitmovin.atlassian.net/browse/AN-4109, https://bitmovin.atlassian.net/browse/AN-4108

Work: 
- Implements the license selection and query selection in the QueryEditor
- Adds ceiling of start timestamps to not show incomplete datapoints at the beginning of a graph

![image](https://github.com/bitmovin/analytics-grafana-datasource/assets/48029745/732fec81-5215-49df-ae9a-00050256f056)

![image](https://github.com/bitmovin/analytics-grafana-datasource/assets/48029745/eb025e8c-4b7f-49ad-88f4-1f18f91e6680)
