### PR TITLE
feature/AN-3212/AN-4131_implement-the-200-row-limit-warning-message

### DIFF
--- a/bitmovin-analytics-datasource/src/datasource.ts
+++ b/bitmovin-analytics-datasource/src/datasource.ts
@@ -6,6 +6,7 @@ import {
   DataSourceApi,
   DataSourceInstanceSettings,
   Field,
+  QueryResultMetaNotice,
 } from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
 import { filter } from 'lodash';
@@ -99,6 +100,7 @@ export class DataSource extends DataSourceApi<BitmovinAnalyticsDataQuery, Bitmov
       );
 
       const dataRows: MixedDataRowList = response.data.data.result.rows;
+      const dataRowCount: number = response.data.data.result.rowCount;
       const columnLabels: Array<{ key: string; label: string }> = response.data.data.result.columnLabels;
 
       const fields: Array<Partial<Field>> = [];
@@ -125,9 +127,20 @@ export class DataSource extends DataSourceApi<BitmovinAnalyticsDataQuery, Bitmov
         }
       }
 
+      let metaNotices: QueryResultMetaNotice[] = [];
+      if (dataRowCount >= 200) {
+        metaNotices = [
+          {
+            severity: 'warning',
+            text: 'Your request reached the max row limit of the API. You might see incomplete data. This problem might be caused by the use of high cardinality columns in group by, too small interval, or too big of a time range.',
+          },
+        ];
+      }
+
       return createDataFrame({
         name: target.aliasBy,
         fields: fields,
+        meta: { notices: metaNotices },
       });
     });
 


### PR DESCRIPTION
# Issue

https://bitmovin.atlassian.net/browse/AN-4131

# Work

Add Warning QueryResultMetaNotice to data frame produced by datasource.ts, when rowCount is higher/equal 200

![Screenshot 2024-06-17 at 18 01 15](https://github.com/bitmovin/analytics-grafana-datasource/assets/3775835/560c6128-d26f-4d40-95dd-31f0de2bae8b)
