### PR TITLE
add default value for percentileValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Development
 
+### Added
+- Default Percentile Value when percentile metric is selected
+
 ## 1.1.1
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Development
 
 ### Added
+
 - Default Percentile Value when percentile metric is selected
 
 ## 1.1.1

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -76,9 +76,7 @@ export function QueryEditor(props: Props) {
       setPercentileValue(95);
       percentile = 95;
     } else {
-      if (percentileValue != null) {
-        setPercentileValue(undefined);
-      }
+      setPercentileValue(undefined);
     }
 
     props.onChange({ ...query, metric: item.value, percentileValue: percentile });

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -69,7 +69,19 @@ export function QueryEditor(props: Props) {
   };
 
   const handleAggregationChange = (item: SelectableValue) => {
-    props.onChange({ ...query, metric: item.value });
+    // set a default value when percentile is selected and delete percentileValue when percentile is deselected
+    // to not pollute the dashboard.json file
+    let percentile = undefined;
+    if (item.value === 'percentile' && percentileValue == null) {
+      setPercentileValue(95);
+      percentile = 95;
+    } else {
+      if (percentileValue != null) {
+        setPercentileValue(undefined);
+      }
+    }
+
+    props.onChange({ ...query, metric: item.value, percentileValue: percentile });
     props.onRunQuery();
   };
 


### PR DESCRIPTION
Work:
- adds default percentileValue when percentile is selected so that first query that gets triggered when percentile metric is selected does not fail
- deletes percentileValue once percentile is deselected to not pollute the dashboard.json file.