### PR TITLE
fix mutating of query start time for multiple queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Development
 
+### Fix
+- different query start times with multiple queries due to mutating of grafana start time
+
 ## 1.1.1
 
 ### Added

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -11,6 +11,8 @@ import {
 } from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
 import { filter, isEmpty } from 'lodash';
+// eslint-disable-next-line  no-restricted-imports
+import moment from 'moment';
 import { catchError, lastValueFrom, map, Observable, of } from 'rxjs';
 
 import {
@@ -101,7 +103,9 @@ export class DataSource extends DataSourceApi<
           ? calculateQueryInterval(target.interval, range!.from.valueOf(), range!.to.valueOf())
           : undefined;
 
-      let queryFrom = range!.from;
+      // create new moment object to not mutate the original grafana object with startOf() to not change
+      // the grafana graph as this would change the timeframe for all the following queries
+      let queryFrom = moment(range!.from.valueOf());
       const queryTo = range!.to;
 
       // floor the query start time to improve cache hitting
@@ -113,9 +117,7 @@ export class DataSource extends DataSourceApi<
         }
         const momentTimeUnit = getMomentTimeUnitForQueryInterval(flooringInterval);
         if (momentTimeUnit != null) {
-          // range from is a moment and startOf is mutating moment object so this has a side effect to also change the
-          // grafana selected timeframe value which will adapt the grafana graph as well
-          queryFrom = range!.from.startOf(momentTimeUnit);
+          queryFrom.startOf(momentTimeUnit);
         }
       }
 


### PR DESCRIPTION
Work: Deletes mutating of grafanas interval start `from` object. The mutating caused inconsistent behaviour for multiple queries, as the mutating in the first query changed the interval start for all the following queries, which led to different interval Auto calculations for e.g 3 hours.
For the 3 hours interval the first query would still return correct `MINUTE` interval, for all the subsequent queries it would return `HOUR` interval as the startTime got rounded down and was the above the minuteIntervalLimit. 