### PR TITLE
fat/AN-4385 make padding calculation for HOUR interval timezone aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Development
 
+### Fix
+
+- wrong padding of timeseries data for `HOUR` interval for timezones with minute offsets
+
 ## 1.3.0
 
 ### Added

--- a/src/utils/dataUtils.test.ts
+++ b/src/utils/dataUtils.test.ts
@@ -29,7 +29,7 @@ describe('calculateTimeSeriesStartTimestamp', () => {
     const result = calculateTimeSeriesStartTimestamp(referenceDataTimestamp, intervalStartTimestamp, 'HOUR');
 
     //assert
-    expect(result).toEqual(1720593000000); // Wednesday, 10 July 2024 06:00:00
+    expect(result).toEqual(1720593000000); // Wednesday, 10 July 2024 06:30:00
   });
 
   it('should return correct timestamp for DAY interval', () => {

--- a/src/utils/dataUtils.test.ts
+++ b/src/utils/dataUtils.test.ts
@@ -22,14 +22,14 @@ describe('calculateTimeSeriesStartTimestamp', () => {
 
   it('should return correct timestamp for HOUR interval', () => {
     //arrange
-    const referenceDataTimestamp = 1720598400000; // Wednesday, 10 July 2024 08:00:00
-    const intervalStartTimestamp = 1720591381300; // Wednesday, 10 July 2024 03:03:01.300
+    const referenceDataTimestamp = 1720600200000; // Wednesday, 10 July 2024 08:30:00
+    const intervalStartTimestamp = 1720591381300; // Wednesday, 10 July 2024 06:03:01.300
 
     //act
     const result = calculateTimeSeriesStartTimestamp(referenceDataTimestamp, intervalStartTimestamp, 'HOUR');
 
     //assert
-    expect(result).toEqual(1720591200000); // Wednesday, 10 July 2024 06:00:00
+    expect(result).toEqual(1720593000000); // Wednesday, 10 July 2024 06:00:00
   });
 
   it('should return correct timestamp for DAY interval', () => {

--- a/src/utils/dataUtils.ts
+++ b/src/utils/dataUtils.ts
@@ -32,7 +32,8 @@ export function calculateTimeSeriesStartTimestamp(
     case 'MINUTE':
       return intervalStartDate.setSeconds(0, 0);
     case 'HOUR':
-      return intervalStartDate.setMinutes(0, 0, 0);
+      // minutes set because of timezones that have a minutes offset
+      return intervalStartDate.setMinutes(referenceDataDate.getMinutes(), 0, 0);
     case 'DAY':
       return intervalStartDate.setHours(referenceDataDate.getHours(), referenceDataDate.getMinutes(), 0, 0);
     case 'MONTH':


### PR DESCRIPTION
Issue: https://bitmovin.atlassian.net/browse/AN-4385

Work: Fixed wrong padding of timeseries data for the `HOUR` interval for timezones with minute offset