### PR TITLE
clone range.from before mutating and delete console.log

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -10,7 +10,7 @@ import {
   RawTimeRange,
 } from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
-import { filter, isEmpty } from 'lodash';
+import { cloneDeep, filter, isEmpty } from 'lodash';
 // eslint-disable-next-line  no-restricted-imports
 import moment from 'moment';
 import { catchError, lastValueFrom, map, Observable, of } from 'rxjs';
@@ -208,7 +208,8 @@ export class DataSource extends DataSourceApi<
 
     // round down grafana start time to adjust the grafana graph and show first data point
     if (momentTimeUnit != null) {
-      range.from.startOf(momentTimeUnit);
+      let fromClone = cloneDeep(range.from);
+      range.from = fromClone.startOf(momentTimeUnit);
     }
 
     return Promise.all(promises).then((data) => ({ data }));

--- a/src/utils/intervalUtils.ts
+++ b/src/utils/intervalUtils.ts
@@ -50,9 +50,6 @@ export const calculateQueryInterval = (
     return interval as QueryInterval;
   }
 
-  console.log('Myriam from:', new Date(startTimestamp));
-  console.log('Myriam to:', new Date(endTimestamp));
-
   const intervalInMilliseconds = endTimestamp - startTimestamp;
   const minuteIntervalLimitInMilliseconds = 3 * 60 * 60 * 1000 + 60000; // MINUTE granularity for timeframes below 3h1m -> 1 minute because of https://github.com/bitmovin/analytics-grafana-datasource/pull/111
   const hourIntervalLimitInMilliseconds = 6 * 24 * 60 * 60 * 1000; // HOUR granularity for timeframes below 6d


### PR DESCRIPTION
Work:
- Deletes console.logs
- Change to not mutate range.from directly but assign cloned and changed object