### PR TITLE
disable e2e tests nightly image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,8 @@ jobs:
       - name: Resolve Grafana E2E versions
         id: resolve-versions
         uses: grafana/plugin-actions/e2e-version@main
+        with:
+          skip-grafana-nightly-image: true
 
   playwright-tests:
     needs: [resolve-versions, build]


### PR DESCRIPTION
The Grafana Nightly Image is pre release and unstable, which can lead to flaky e2e tests. No need for us to include this image in our e2e tests.