### PR TITLE
Feat/grafana variables support

### DIFF
--- a/dist/plugin.json
+++ b/dist/plugin.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json",
   "type": "datasource",
-  "name": "Bitmovin Analytics (Dev)",
-  "id": "bitmovin-analytics-datasource-dev",
+  "name": "Bitmovin Analytics",
+  "id": "bitmovin-analytics-datasource",
   "metrics": true,
   "info": {
     "description": "Data source plugin which allows you to query Analytics data from the Bitmovin API",

--- a/dist/plugin.json
+++ b/dist/plugin.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json",
   "type": "datasource",
-  "name": "Bitmovin Analytics",
-  "id": "bitmovin-analytics-datasource",
+  "name": "Bitmovin Analytics (Dev)",
+  "id": "bitmovin-analytics-datasource-dev",
   "metrics": true,
   "info": {
     "description": "Data source plugin which allows you to query Analytics data from the Bitmovin API",

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -1,5 +1,5 @@
 import React, { ChangeEvent, useEffect, useMemo, useState } from 'react';
-import { FieldSet, HorizontalGroup, InlineField, InlineSwitch, Input, Select } from '@grafana/ui';
+import { Button, FieldSet, HorizontalGroup, InlineField, InlineSwitch, Input, Select } from '@grafana/ui';
 import type { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { defaults } from 'lodash';
 
@@ -65,6 +65,19 @@ export function QueryEditor(props: Props) {
 
   const handleLicenseChange = (item: SelectableValue) => {
     props.onChange({ ...query, license: item.value });
+    props.onRunQuery();
+  };
+
+  const handleLicenseModeToggle = () => {
+    props.onChange({ ...query, useVariableForLicense: !query.useVariableForLicense, license: '' });
+    props.onRunQuery();
+  };
+
+  const handleLicenseVariableChange = (event: ChangeEvent<HTMLInputElement>) => {
+    props.onChange({ ...query, license: event.target.value });
+  };
+
+  const handleLicenseVariableBlur = () => {
     props.onRunQuery();
   };
 
@@ -167,21 +180,42 @@ export function QueryEditor(props: Props) {
         <InlineField
           label="License"
           labelWidth={20}
-          invalid={licenseLoadingState === LoadingState.Error}
+          invalid={!query.useVariableForLicense && licenseLoadingState === LoadingState.Error}
           error={`Error when fetching Analytics Licenses: ${licenseErrorMessage}`}
-          disabled={licenseLoadingState === LoadingState.Error}
+          disabled={!query.useVariableForLicense && licenseLoadingState === LoadingState.Error}
           required
         >
-          <Select
-            id={`query-editor-${props.query.refId}_license-select`}
-            value={query.license}
-            onChange={handleLicenseChange}
-            width={30}
-            options={selectableLicenses}
-            noOptionsMessage="No Analytics Licenses found"
-            isLoading={licenseLoadingState === LoadingState.Loading}
-            placeholder={licenseLoadingState === LoadingState.Loading ? 'Loading Licenses' : 'Choose License'}
-          />
+          <HorizontalGroup spacing="xs">
+            {query.useVariableForLicense ? (
+              <Input
+                id={`query-editor-${props.query.refId}_license-variable-input`}
+                value={query.license}
+                onChange={handleLicenseVariableChange}
+                onBlur={handleLicenseVariableBlur}
+                width={30}
+                placeholder="${licenseVar}"
+              />
+            ) : (
+              <Select
+                id={`query-editor-${props.query.refId}_license-select`}
+                value={query.license}
+                onChange={handleLicenseChange}
+                width={30}
+                options={selectableLicenses}
+                noOptionsMessage="No Analytics Licenses found"
+                isLoading={licenseLoadingState === LoadingState.Loading}
+                placeholder={licenseLoadingState === LoadingState.Loading ? 'Loading Licenses' : 'Choose License'}
+              />
+            )}
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={handleLicenseModeToggle}
+              tooltip={query.useVariableForLicense ? 'Switch to license picker' : 'Use a dashboard variable'}
+            >
+              {query.useVariableForLicense ? '↩ Pick' : '$ Use variable'}
+            </Button>
+          </HorizontalGroup>
         </InlineField>
         <HorizontalGroup spacing="xs">
           {!isMetricSelected && (

--- a/src/components/QueryFilterInput.tsx
+++ b/src/components/QueryFilterInput.tsx
@@ -10,6 +10,7 @@ import {
 } from '../types/queryAttributes';
 import { QueryAdAttribute, SELECTABLE_QUERY_AD_ATTRIBUTES } from '../types/queryAdAttributes';
 import { convertFilterValueToProperType } from 'utils/filterUtils';
+import { inferFieldValueType } from '../utils/fieldTypes';
 
 interface QueryFilterInputProps {
   /** `undefined` when component is used to create new filter (no values yet) */
@@ -156,14 +157,33 @@ export function QueryFilterInput(props: Readonly<QueryFilterInputProps>) {
         show={derivedQueryFilterState.inputValueError != null}
         theme="error"
       >
-        <Input
-          data-testid={`query-editor-${props.queryEditorId}_filter-value-input`}
-          value={derivedQueryFilterState.value}
-          onChange={(e) => handleInputValueChange(e.currentTarget.value)}
-          invalid={derivedQueryFilterState.inputValueError != null}
-          type="text"
-          width={VALUE_COMPONENT_WIDTH}
-        />
+        {derivedQueryFilterState.attribute &&
+        inferFieldValueType(derivedQueryFilterState.attribute as QueryAttribute | QueryAdAttribute) === 'boolean' &&
+        derivedQueryFilterState.operator !== 'IN' ? (
+          <div>
+            <Select
+              data-testid={`query-editor-${props.queryEditorId}_filter-value-input`}
+              value={derivedQueryFilterState.value}
+              options={[
+                { label: 'true', value: 'true' },
+                { label: 'false', value: 'false' },
+              ]}
+              onChange={(v) => handleInputValueChange(v.value ?? '')}
+              invalid={derivedQueryFilterState.inputValueError != null}
+              width={VALUE_COMPONENT_WIDTH}
+            />
+          </div>
+        ) : (
+          <Input
+            data-testid={`query-editor-${props.queryEditorId}_filter-value-input`}
+            value={derivedQueryFilterState.value}
+            onChange={(e) => handleInputValueChange(e.currentTarget.value)}
+            invalid={derivedQueryFilterState.inputValueError != null}
+            placeholder={derivedQueryFilterState.operator === 'IN' ? '["value1", "value2"] or use a multi-value Grafana variable' : undefined}
+            type="text"
+            width={VALUE_COMPONENT_WIDTH}
+          />
+        )}
       </Tooltip>
 
       <IconButton

--- a/src/components/VariableQueryEditor.tsx
+++ b/src/components/VariableQueryEditor.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Input } from '@grafana/ui';
+
+interface VariableQueryEditorProps {
+  query: string;
+  onChange: (query: string) => void;
+}
+
+export function VariableQueryEditor({ query, onChange }: VariableQueryEditorProps) {
+  return (
+    <Input
+      value={query}
+      placeholder='dimension:COUNTRY  or  dimension:BROWSER license:YOUR_LICENSE_KEY'
+      onChange={(e) => onChange(e.currentTarget.value)}
+    />
+  );
+}

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -72,11 +72,12 @@ describe('DataSource.applyTemplateVariables', () => {
     expect(result.alias).toBe('Panel DE');
   });
 
-  it('replaces a template variable in license', () => {
+  it('replaces a template variable in license when useVariableForLicense is true', () => {
     const ds = createDataSource();
     const query = {
       refId: 'A',
       license: '${licenseKey}',
+      useVariableForLicense: true,
       alias: '',
       filter: [],
       groupBy: [],
@@ -88,6 +89,24 @@ describe('DataSource.applyTemplateVariables', () => {
     const result = ds.applyTemplateVariables(query, scopedVars);
 
     expect(result.license).toBe('abc-123');
+  });
+
+  it('does not interpolate license when useVariableForLicense is false', () => {
+    const ds = createDataSource();
+    const query = {
+      refId: 'A',
+      license: 'static-license-key',
+      useVariableForLicense: false,
+      alias: '',
+      filter: [],
+      groupBy: [],
+      orderBy: [],
+      resultFormat: 'time_series' as const,
+    };
+
+    const result = ds.applyTemplateVariables(query, { licenseKey: { text: 'abc-123', value: 'abc-123' } });
+
+    expect(result.license).toBe('static-license-key');
   });
 
   it('leaves values unchanged when no matching scopedVars', () => {
@@ -134,7 +153,7 @@ describe('DataSource.metricFindQuery', () => {
       data: {
         data: {
           result: {
-            licenses: [{ licenseKey }],
+            items: [{ licenseKey }],
           },
         },
       },
@@ -193,6 +212,41 @@ describe('DataSource.metricFindQuery', () => {
 
     expect(result).toEqual([]);
   });
+
+  it('returns licenses list for "licenses" keyword', async () => {
+    const ds = createDataSource();
+    mockRequest.mockReturnValueOnce(of({ data: { data: { result: { items: [
+      { licenseKey: 'key-1', name: 'My App' },
+      { licenseKey: 'key-2', name: 'Other App' },
+    ] } } } }));
+
+    const result = await ds.metricFindQuery('licenses');
+
+    expect(result).toEqual([
+      { text: 'My App', value: 'key-1' },
+      { text: 'Other App', value: 'key-2' },
+    ]);
+  });
+
+  it('handles "LICENSES" keyword case-insensitively', async () => {
+    const ds = createDataSource();
+    mockRequest.mockReturnValueOnce(of({ data: { data: { result: { items: [
+      { licenseKey: 'key-1', name: 'My App' },
+    ] } } } }));
+
+    const result = await ds.metricFindQuery('LICENSES');
+
+    expect(result).toEqual([{ text: 'My App', value: 'key-1' }]);
+  });
+
+  it('returns empty array for "licenses" keyword on API error', async () => {
+    const ds = createDataSource();
+    mockRequest.mockReturnValueOnce({ subscribe: (obs: any) => obs.error(new Error('API error')) });
+
+    const result = await ds.metricFindQuery('licenses');
+
+    expect(result).toEqual([]);
+  });
 });
 
 describe('DataSource.getTagKeys', () => {
@@ -215,7 +269,7 @@ describe('DataSource.getTagValues', () => {
     const ds = createDataSource();
     mockRequest
       .mockReturnValueOnce(of({
-        data: { data: { result: { licenses: [{ licenseKey: 'test-license' }] } } },
+        data: { data: { result: { items: [{ licenseKey: 'test-license' }] } } },
       }))
       .mockReturnValueOnce(of({
         data: { data: { result: { rows: [['DE', 1], ['US', 1]], rowCount: 2, columnLabels: [] } } },
@@ -232,7 +286,7 @@ describe('DataSource.getTagValues', () => {
   it('returns empty array when no license is available', async () => {
     const ds = createDataSource();
     mockRequest.mockReturnValueOnce(of({
-      data: { data: { result: { licenses: [] } } },
+      data: { data: { result: { items: [] } } },
     }));
 
     const result = await ds.getTagValues({ key: 'COUNTRY' });

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -4,15 +4,19 @@ import { BitmovinDataSourceOptions } from './types/grafanaTypes';
 import { of } from 'rxjs';
 
 const mockRequest = jest.fn();
+const mockDashboardVars: Record<string, string> = {};
 
 jest.mock('@grafana/runtime', () => ({
   getBackendSrv: () => ({ fetch: mockRequest }),
   getTemplateSrv: () => ({
     replace: (value: string, scopedVars?: Record<string, { value: string }>) => {
-      if (!value || !scopedVars) {
+      if (!value) {
         return value;
       }
-      return value.replace(/\$\{(\w+)\}/g, (_, key) => scopedVars[key]?.value ?? `\${${key}}`);
+      const vars = scopedVars
+        ? Object.fromEntries(Object.entries(scopedVars).map(([k, v]) => [k, v.value]))
+        : mockDashboardVars;
+      return value.replace(/\$\{(\w+)\}/g, (_, key) => vars[key] ?? `\${${key}}`);
     },
   }),
 }));
@@ -246,6 +250,21 @@ describe('DataSource.metricFindQuery', () => {
     const result = await ds.metricFindQuery('licenses');
 
     expect(result).toEqual([]);
+  });
+
+  it('interpolates dashboard variables in query text before parsing', async () => {
+    const ds = createDataSource();
+    mockDashboardVars['licenseVar'] = 'resolved-license';
+    mockRequest.mockReturnValueOnce(makeCountResponse(['DE', 'US']));
+
+    const result = await ds.metricFindQuery('dimension:COUNTRY license:${licenseVar}');
+
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([
+      { text: 'DE', value: 'DE' },
+      { text: 'US', value: 'US' },
+    ]);
+    delete mockDashboardVars['licenseVar'];
   });
 });
 

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -1,0 +1,108 @@
+import { DataSource } from './datasource';
+import { DataSourceInstanceSettings } from '@grafana/data';
+import { BitmovinDataSourceOptions } from './types/grafanaTypes';
+
+jest.mock('@grafana/runtime', () => ({
+  getBackendSrv: jest.fn(),
+  getTemplateSrv: () => ({
+    replace: (value: string, scopedVars?: Record<string, { value: string }>) => {
+      if (!value || !scopedVars) {
+        return value;
+      }
+      return value.replace(/\$\{(\w+)\}/g, (_, key) => scopedVars[key]?.value ?? `\${${key}}`);
+    },
+  }),
+}));
+
+function createDataSource(): DataSource {
+  const instanceSettings = {
+    id: 1,
+    uid: 'test',
+    name: 'Bitmovin Test',
+    type: 'bitmovin-analytics-datasource',
+    url: 'http://localhost',
+    jsonData: {
+      apiKey: 'test-key',
+    },
+    meta: {} as any,
+    readOnly: false,
+    access: 'proxy' as any,
+  } as DataSourceInstanceSettings<BitmovinDataSourceOptions>;
+
+  return new DataSource(instanceSettings);
+}
+
+describe('DataSource.applyTemplateVariables', () => {
+  it('replaces a template variable in a filter value', () => {
+    const ds = createDataSource();
+    const query = {
+      refId: 'A',
+      license: 'my-license',
+      alias: '',
+      filter: [{ name: 'COUNTRY', operator: 'EQ', value: '${country}' }],
+      groupBy: [],
+      orderBy: [],
+      resultFormat: 'time_series' as const,
+    };
+    const scopedVars = { country: { text: 'DE', value: 'DE' } };
+
+    const result = ds.applyTemplateVariables(query, scopedVars);
+
+    expect(result.filter[0].value).toBe('DE');
+  });
+
+  it('replaces a template variable in alias', () => {
+    const ds = createDataSource();
+    const query = {
+      refId: 'A',
+      license: 'my-license',
+      alias: 'Panel ${country}',
+      filter: [],
+      groupBy: [],
+      orderBy: [],
+      resultFormat: 'time_series' as const,
+    };
+    const scopedVars = { country: { text: 'DE', value: 'DE' } };
+
+    const result = ds.applyTemplateVariables(query, scopedVars);
+
+    expect(result.alias).toBe('Panel DE');
+  });
+
+  it('replaces a template variable in license', () => {
+    const ds = createDataSource();
+    const query = {
+      refId: 'A',
+      license: '${licenseKey}',
+      alias: '',
+      filter: [],
+      groupBy: [],
+      orderBy: [],
+      resultFormat: 'time_series' as const,
+    };
+    const scopedVars = { licenseKey: { text: 'abc-123', value: 'abc-123' } };
+
+    const result = ds.applyTemplateVariables(query, scopedVars);
+
+    expect(result.license).toBe('abc-123');
+  });
+
+  it('leaves values unchanged when no matching scopedVars', () => {
+    const ds = createDataSource();
+    const query = {
+      refId: 'A',
+      license: 'static-license',
+      alias: 'static-alias',
+      filter: [{ name: 'COUNTRY', operator: 'EQ', value: 'DE' }],
+      groupBy: [],
+      orderBy: [],
+      resultFormat: 'time_series' as const,
+    };
+
+    const result = ds.applyTemplateVariables(query, {});
+
+    expect(result.license).toBe('static-license');
+    expect(result.alias).toBe('static-alias');
+    expect(result.filter[0].value).toBe('DE');
+  });
+});

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -1,9 +1,12 @@
 import { DataSource } from './datasource';
 import { DataSourceInstanceSettings } from '@grafana/data';
 import { BitmovinDataSourceOptions } from './types/grafanaTypes';
+import { of } from 'rxjs';
+
+const mockRequest = jest.fn();
 
 jest.mock('@grafana/runtime', () => ({
-  getBackendSrv: jest.fn(),
+  getBackendSrv: () => ({ fetch: mockRequest }),
   getTemplateSrv: () => ({
     replace: (value: string, scopedVars?: Record<string, { value: string }>) => {
       if (!value || !scopedVars) {
@@ -104,5 +107,136 @@ describe('DataSource.applyTemplateVariables', () => {
     expect(result.license).toBe('static-license');
     expect(result.alias).toBe('static-alias');
     expect(result.filter[0].value).toBe('DE');
+  });
+});
+
+describe('DataSource.metricFindQuery', () => {
+  beforeEach(() => {
+    mockRequest.mockReset();
+  });
+
+  function makeCountResponse(values: string[]) {
+    return of({
+      data: {
+        data: {
+          result: {
+            rows: values.map((v) => [v, 1]),
+            rowCount: values.length,
+            columnLabels: [],
+          },
+        },
+      },
+    });
+  }
+
+  function makeLicenseResponse(licenseKey: string) {
+    return of({
+      data: {
+        data: {
+          result: {
+            licenses: [{ licenseKey }],
+          },
+        },
+      },
+    });
+  }
+
+  it('returns metric find values from API rows', async () => {
+    const ds = createDataSource();
+    mockRequest
+      .mockReturnValueOnce(makeLicenseResponse('test-license'))
+      .mockReturnValueOnce(makeCountResponse(['DE', 'US', 'GB']));
+
+    const result = await ds.metricFindQuery('dimension:COUNTRY');
+
+    expect(result).toEqual([
+      { text: 'DE', value: 'DE' },
+      { text: 'US', value: 'US' },
+      { text: 'GB', value: 'GB' },
+    ]);
+  });
+
+  it('uses license from query string when provided', async () => {
+    const ds = createDataSource();
+    mockRequest.mockReturnValueOnce(makeCountResponse(['DE', 'US']));
+
+    const result = await ds.metricFindQuery('dimension:COUNTRY license:explicit-key');
+
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([
+      { text: 'DE', value: 'DE' },
+      { text: 'US', value: 'US' },
+    ]);
+  });
+
+  it('returns empty array for empty query', async () => {
+    const ds = createDataSource();
+    const result = await ds.metricFindQuery('');
+    expect(result).toEqual([]);
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+
+  it('returns empty array when query has no dimension', async () => {
+    const ds = createDataSource();
+    const result = await ds.metricFindQuery('invalid');
+    expect(result).toEqual([]);
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+
+  it('returns empty array on API error', async () => {
+    const ds = createDataSource();
+    mockRequest
+      .mockReturnValueOnce(makeLicenseResponse('test-license'))
+      .mockReturnValueOnce({ subscribe: (obs: any) => obs.error(new Error('API error')) });
+
+    const result = await ds.metricFindQuery('dimension:COUNTRY');
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe('DataSource.getTagKeys', () => {
+  it('returns an entry for COUNTRY, BROWSER, and PLATFORM', async () => {
+    const ds = createDataSource();
+    const result = await ds.getTagKeys();
+    const texts = result.map((r) => r.text);
+    expect(texts).toContain('COUNTRY');
+    expect(texts).toContain('BROWSER');
+    expect(texts).toContain('PLATFORM');
+  });
+});
+
+describe('DataSource.getTagValues', () => {
+  beforeEach(() => {
+    mockRequest.mockReset();
+  });
+
+  it('calls metricFindQuery with the correct dimension', async () => {
+    const ds = createDataSource();
+    mockRequest
+      .mockReturnValueOnce(of({
+        data: { data: { result: { licenses: [{ licenseKey: 'test-license' }] } } },
+      }))
+      .mockReturnValueOnce(of({
+        data: { data: { result: { rows: [['DE', 1], ['US', 1]], rowCount: 2, columnLabels: [] } } },
+      }));
+
+    const result = await ds.getTagValues({ key: 'COUNTRY' });
+
+    expect(result).toEqual([
+      { text: 'DE', value: 'DE' },
+      { text: 'US', value: 'US' },
+    ]);
+  });
+
+  it('returns empty array when no license is available', async () => {
+    const ds = createDataSource();
+    mockRequest.mockReturnValueOnce(of({
+      data: { data: { result: { licenses: [] } } },
+    }));
+
+    const result = await ds.getTagValues({ key: 'COUNTRY' });
+
+    expect(result).toEqual([]);
   });
 });

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -81,6 +81,30 @@ export class DataSource extends DataSourceApi<
     return DEFAULT_QUERY;
   }
 
+  getQueryDisplayText(query: BitmovinAnalyticsDataQuery): string {
+    const parts: string[] = [];
+
+    if (query.metric && query.dimension) {
+      parts.push(`${query.metric}(${query.dimension})`);
+    } else if (query.dimension) {
+      parts.push(query.dimension);
+    }
+
+    if (query.groupBy?.length > 0) {
+      parts.push(`by ${query.groupBy.join(', ')}`);
+    }
+
+    if (query.filter?.length > 0) {
+      const filterSummary = query.filter
+        .slice(0, 2)
+        .map((f) => `${f.name} ${f.operator} ${f.value}`)
+        .join(', ');
+      parts.push(`where ${filterSummary}${query.filter.length > 2 ? ' ...' : ''}`);
+    }
+
+    return parts.join(' · ') || 'Bitmovin Analytics';
+  }
+
   applyTemplateVariables(
     query: BitmovinAnalyticsDataQuery,
     scopedVars: ScopedVars
@@ -245,7 +269,10 @@ export class DataSource extends DataSourceApi<
       return createDataFrame({
         name: alias,
         fields: fields,
-        meta: { notices: metaNotices },
+        meta: {
+          notices: metaNotices,
+          preferredVisualisationType: query.interval ? 'graph' : 'table',
+        },
       });
     });
 

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -6,10 +6,12 @@ import {
   DataSourceApi,
   DataSourceInstanceSettings,
   Field,
+  MetricFindValue,
   QueryResultMetaNotice,
   RawTimeRange,
+  ScopedVars,
 } from '@grafana/data';
-import { getBackendSrv } from '@grafana/runtime';
+import { getBackendSrv, getTemplateSrv } from '@grafana/runtime';
 import { cloneDeep, filter, isEmpty } from 'lodash';
 // eslint-disable-next-line  no-restricted-imports
 import moment from 'moment';
@@ -78,6 +80,21 @@ export class DataSource extends DataSourceApi<
     return DEFAULT_QUERY;
   }
 
+  applyTemplateVariables(
+    query: BitmovinAnalyticsDataQuery,
+    scopedVars: ScopedVars
+  ): BitmovinAnalyticsDataQuery {
+    return {
+      ...query,
+      license: getTemplateSrv().replace(query.license, scopedVars),
+      alias: getTemplateSrv().replace(query.alias ?? '', scopedVars),
+      filter: query.filter.map((f) => ({
+        ...f,
+        value: getTemplateSrv().replace(f.value, scopedVars),
+      })),
+    };
+  }
+
   /**
    * The Bitmovin API Response follows these rules:
    * - If the interval property is provided in the request query, time series data is returned and the first value of each row is a timestamp in milliseconds.
@@ -135,13 +152,31 @@ export class DataSource extends DataSourceApi<
         }
       }
 
-      const filters: ProperTypedQueryFilter[] = target.filter.map((filter) => {
-        return {
-          name: filter.name,
-          operator: filter.operator,
-          value: convertFilterValueToProperType(filter.value, filter.name, filter.operator, !!this.isAdAnalytics),
-        };
-      });
+      const filters = target.filter
+        .map((filter) => {
+          const interpolatedValue = getTemplateSrv().replace(filter.value, options.scopedVars);
+
+          if (interpolatedValue === '$__all' || interpolatedValue === '.*' || interpolatedValue === '') {
+            return null;
+          }
+
+          // Grafana resolves "All" to a glob like {AR,CO,EC,MX} when no custom all-value is set.
+          // Skip for non-IN operators — EQ with multiple values is never valid.
+          // IN keeps the glob so T-02 can normalize it to a JSON array.
+          if (filter.operator !== 'IN' && /^\{.+\}$/.test(interpolatedValue)) {
+            return null;
+          }
+
+          return {
+            name: filter.name,
+            operator: filter.operator,
+            value: convertFilterValueToProperType(interpolatedValue, filter.name, filter.operator, !!this.isAdAnalytics),
+          };
+        })
+        .filter((f) => f !== null) as ProperTypedQueryFilter[];
+
+      const alias = getTemplateSrv().replace(target.alias ?? '', options.scopedVars);
+      const licenseKey = getTemplateSrv().replace(target.license, options.scopedVars);
 
       const query: BitmovinAnalyticsRequestQuery = {
         filters: filters,
@@ -151,7 +186,7 @@ export class DataSource extends DataSourceApi<
         metric: metric,
         start: queryFrom.toDate(),
         end: queryTo.toDate(),
-        licenseKey: target.license,
+        licenseKey: licenseKey,
         interval: interval,
         limit: this.parseLimit(target.limit),
         percentile: percentileValue,
@@ -200,7 +235,7 @@ export class DataSource extends DataSourceApi<
       }
 
       return createDataFrame({
-        name: target.alias,
+        name: alias,
         fields: fields,
         meta: { notices: metaNotices },
       });

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -335,11 +335,13 @@ export class DataSource extends DataSourceApi<
   }
 
   async metricFindQuery(queryText: string): Promise<MetricFindValue[]> {
-    if (!queryText?.trim()) {
+const interpolated = getTemplateSrv().replace(queryText);
+
+    if (!interpolated?.trim()) {
       return [];
     }
 
-    if (queryText.trim().toLowerCase() === 'licenses') {
+    if (interpolated.trim().toLowerCase() === 'licenses') {
       try {
         const response = await lastValueFrom(this.request('/analytics/licenses', 'GET'));
         const items: Array<{ licenseKey: string; name?: string }> = response.data.data.result.items ?? [];
@@ -351,15 +353,19 @@ export class DataSource extends DataSourceApi<
       }
     }
 
-    const dimensionMatch = queryText.match(/dimension:(\S+)/);
-    const licenseMatch = queryText.match(/license:(\S+)/);
+    const dimensionMatch = interpolated.match(/dimension:(\S+)/);
+    const licenseMatch = interpolated.match(/license:(\S+)/);
 
     if (!dimensionMatch) {
       return [];
     }
 
     const dimension = dimensionMatch[1] as QueryAttribute;
-    const licenseKey = licenseMatch ? licenseMatch[1] : await this.getFirstLicenseKey();
+    const rawLicenseKey = licenseMatch?.[1];
+    const licenseKey =
+      rawLicenseKey && !/^\$/.test(rawLicenseKey)
+        ? rawLicenseKey
+        : await this.getFirstLicenseKey();
 
     if (!licenseKey) {
       return [];

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -39,7 +39,7 @@ import {
 import { isMetric, Metric } from './types/metric';
 import { AggregationMethod } from './types/aggregationMethod';
 import { ProperTypedQueryFilter } from './types/queryFilter';
-import { QueryAttribute } from './types/queryAttributes';
+import { QueryAttribute, SELECTABLE_QUERY_FILTER_ATTRIBUTES } from './types/queryAttributes';
 import { QueryAdAttribute } from './types/queryAdAttributes';
 import { QueryOrderBy } from './types/queryOrderBy';
 import { convertFilterValueToProperType } from './utils/filterUtils';
@@ -316,6 +316,74 @@ export class DataSource extends DataSourceApi<
     };
 
     return getBackendSrv().fetch(options);
+  }
+
+  async getTagKeys(): Promise<Array<{ text: string }>> {
+    return SELECTABLE_QUERY_FILTER_ATTRIBUTES.map((attr) => ({ text: attr.value! }));
+  }
+
+  async getTagValues(options: { key: string }): Promise<Array<{ text: string }>> {
+    const licenseKey = await this.getFirstLicenseKey();
+    if (!licenseKey) {
+      return [];
+    }
+    return this.metricFindQuery(`dimension:${options.key} license:${licenseKey}`);
+  }
+
+  async metricFindQuery(queryText: string): Promise<MetricFindValue[]> {
+    if (!queryText?.trim()) {
+      return [];
+    }
+
+    const dimensionMatch = queryText.match(/dimension:(\S+)/);
+    const licenseMatch = queryText.match(/license:(\S+)/);
+
+    if (!dimensionMatch) {
+      return [];
+    }
+
+    const dimension = dimensionMatch[1] as QueryAttribute;
+    const licenseKey = licenseMatch ? licenseMatch[1] : await this.getFirstLicenseKey();
+
+    if (!licenseKey) {
+      return [];
+    }
+
+    const end = new Date();
+    const start = new Date(end.getTime() - 24 * 60 * 60 * 1000);
+
+    const query = {
+      licenseKey,
+      start,
+      end,
+      dimension: 'IMPRESSION_ID' as QueryAttribute,
+      groupBy: [dimension],
+      orderBy: [],
+      filters: [],
+      limit: 200,
+    };
+
+    try {
+      const response = await lastValueFrom(
+        this.request('/analytics/queries/count', 'POST', query)
+      );
+      const rows: MixedDataRowList = response.data.data.result.rows;
+      return rows
+        .map((row) => row[0])
+        .filter((v) => v != null && v !== '')
+        .map((v) => ({ text: String(v), value: String(v) }));
+    } catch {
+      return [];
+    }
+  }
+
+  private async getFirstLicenseKey(): Promise<string | undefined> {
+    try {
+      const response = await lastValueFrom(this.request('/analytics/licenses', 'GET'));
+      return response.data.data.result.licenses?.[0]?.licenseKey;
+    } catch {
+      return undefined;
+    }
   }
 
   async testDatasource() {

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -43,6 +43,7 @@ import { QueryAttribute, SELECTABLE_QUERY_FILTER_ATTRIBUTES } from './types/quer
 import { QueryAdAttribute } from './types/queryAdAttributes';
 import { QueryOrderBy } from './types/queryOrderBy';
 import { convertFilterValueToProperType } from './utils/filterUtils';
+import { inferFieldConfig } from './utils/fieldConfig';
 
 type BitmovinAnalyticsRequestQuery = {
   licenseKey: string;
@@ -154,6 +155,8 @@ export class DataSource extends DataSourceApi<
         }
       }
 
+      const fieldConfig = inferFieldConfig(dimension ?? metric);
+
       const filters = target.filter
         .map((filter) => {
           const interpolatedValue = getTemplateSrv().replace(filter.value, options.scopedVars);
@@ -208,7 +211,7 @@ export class DataSource extends DataSourceApi<
       if (query.interval && query.groupBy?.length > 0) {
         // If the query has an interval and group by columns, transform the data as grouped time series
         fields.push(
-          ...transformGroupedTimeSeriesData(dataRows, queryFrom.valueOf(), queryTo.valueOf(), query.interval)
+          ...transformGroupedTimeSeriesData(dataRows, queryFrom.valueOf(), queryTo.valueOf(), query.interval, fieldConfig)
         );
       } else {
         if (query.interval) {
@@ -219,12 +222,13 @@ export class DataSource extends DataSourceApi<
               columnLabels.length > 0 ? columnLabels[columnLabels.length - 1].label : 'Column 1',
               queryFrom.valueOf(),
               queryTo.valueOf(),
-              query.interval
+              query.interval,
+              fieldConfig
             )
           );
         } else {
           // If no interval is specified, transform the data as table data
-          fields.push(...transformTableData(dataRows, columnLabels));
+          fields.push(...transformTableData(dataRows, columnLabels, fieldConfig));
         }
       }
 

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -86,7 +86,9 @@ export class DataSource extends DataSourceApi<
   ): BitmovinAnalyticsDataQuery {
     return {
       ...query,
-      license: getTemplateSrv().replace(query.license, scopedVars),
+      license: query.useVariableForLicense
+        ? getTemplateSrv().replace(query.license, scopedVars)
+        : query.license,
       alias: getTemplateSrv().replace(query.alias ?? '', scopedVars),
       filter: query.filter.map((f) => ({
         ...f,
@@ -176,7 +178,9 @@ export class DataSource extends DataSourceApi<
         .filter((f) => f !== null) as ProperTypedQueryFilter[];
 
       const alias = getTemplateSrv().replace(target.alias ?? '', options.scopedVars);
-      const licenseKey = getTemplateSrv().replace(target.license, options.scopedVars);
+      const licenseKey = target.useVariableForLicense
+        ? getTemplateSrv().replace(target.license, options.scopedVars)
+        : target.license;
 
       const query: BitmovinAnalyticsRequestQuery = {
         filters: filters,
@@ -335,6 +339,18 @@ export class DataSource extends DataSourceApi<
       return [];
     }
 
+    if (queryText.trim().toLowerCase() === 'licenses') {
+      try {
+        const response = await lastValueFrom(this.request('/analytics/licenses', 'GET'));
+        const items: Array<{ licenseKey: string; name?: string }> = response.data.data.result.items ?? [];
+        return items
+          .filter((l) => l.licenseKey != null)
+          .map((l) => ({ text: l.name || l.licenseKey, value: l.licenseKey }));
+      } catch {
+        return [];
+      }
+    }
+
     const dimensionMatch = queryText.match(/dimension:(\S+)/);
     const licenseMatch = queryText.match(/license:(\S+)/);
 
@@ -380,7 +396,7 @@ export class DataSource extends DataSourceApi<
   private async getFirstLicenseKey(): Promise<string | undefined> {
     try {
       const response = await lastValueFrom(this.request('/analytics/licenses', 'GET'));
-      return response.data.data.result.licenses?.[0]?.licenseKey;
+      return response.data.data.result.items?.[0]?.licenseKey;
     } catch {
       return undefined;
     }

--- a/src/module.ts
+++ b/src/module.ts
@@ -2,6 +2,7 @@ import { DataSourcePlugin } from '@grafana/data';
 import { DataSource } from './datasource';
 import { ConfigEditor } from './components/ConfigEditor';
 import { QueryEditor } from './components/QueryEditor';
+import { VariableQueryEditor } from './components/VariableQueryEditor';
 import {
   BitmovinAnalyticsDataQuery,
   BitmovinDataSourceOptions,
@@ -14,4 +15,5 @@ export const plugin = new DataSourcePlugin<
   BitmovinDataSourceOptions
 >(DataSource)
   .setConfigEditor(ConfigEditor)
-  .setQueryEditor(QueryEditor);
+  .setQueryEditor(QueryEditor)
+  .setVariableQueryEditor(VariableQueryEditor);

--- a/src/types/grafanaTypes.ts
+++ b/src/types/grafanaTypes.ts
@@ -15,6 +15,7 @@ type ResultFormat = 'table' | 'time_series';
  * */
 export interface BitmovinAnalyticsDataQuery extends DataQuery {
   license: string;
+  useVariableForLicense?: boolean;
   interval?: QueryInterval | 'AUTO';
   metric?: AggregationMethod;
   dimension?: QueryAttribute | QueryAdAttribute | Metric;

--- a/src/utils/dataUtils.test.ts
+++ b/src/utils/dataUtils.test.ts
@@ -354,10 +354,10 @@ describe('transformGroupedTimeSeriesData', () => {
         values: [1712919540000, 1712919600000, 1712919660000, 1712919720000, 1712919780000],
         type: FieldType.time,
       },
-      { name: 'Firefox, Mac', values: [3, 0, 9, 0, 0], type: FieldType.number },
-      { name: 'Safari, Mac', values: [3, 10, 0, 0, 0], type: FieldType.number },
-      { name: 'Safari, iPhone', values: [6, 0, 0, 10, 0], type: FieldType.number },
-      { name: 'Chrome Mobile, iPhone', values: [0, 0, 0, 0, 1], type: FieldType.number },
+      { name: 'Firefox, Mac', values: [3, 0, 9, 0, 0], type: FieldType.number, config: {} },
+      { name: 'Safari, Mac', values: [3, 10, 0, 0, 0], type: FieldType.number, config: {} },
+      { name: 'Safari, iPhone', values: [6, 0, 0, 10, 0], type: FieldType.number, config: {} },
+      { name: 'Chrome Mobile, iPhone', values: [0, 0, 0, 0, 1], type: FieldType.number, config: {} },
     ]);
   });
 
@@ -418,7 +418,7 @@ describe('transformSimpleTimeSeries', () => {
         values: [1712919540000, 1712919600000, 1712919660000, 1712919720000, 1712919780000],
         type: FieldType.time,
       },
-      { name: 'Impression Id', values: [3, 10, 0, 0, 1], type: FieldType.number },
+      { name: 'Impression Id', values: [3, 10, 0, 0, 1], type: FieldType.number, config: {} },
     ]);
   });
 
@@ -485,7 +485,7 @@ describe('transformTableData', () => {
         values: ['Mac', 'iPhone', 'iPhone', 'Pixel 7'],
         type: FieldType.string,
       },
-      { name: 'Impression Id', values: [3, 10, 1, 4], type: FieldType.number },
+      { name: 'Impression Id', values: [3, 10, 1, 4], type: FieldType.number, config: {} },
     ]);
   });
 
@@ -522,7 +522,7 @@ describe('transformTableData', () => {
         values: ['Mac', 'iPhone', 'iPhone', 'Pixel 7'],
         type: FieldType.string,
       },
-      { name: 'Column 3', values: [3, 10, 1, 4], type: FieldType.number },
+      { name: 'Column 3', values: [3, 10, 1, 4], type: FieldType.number, config: {} },
     ]);
   });
 });

--- a/src/utils/dataUtils.ts
+++ b/src/utils/dataUtils.ts
@@ -1,6 +1,6 @@
 import { differenceWith, sortBy, zip } from 'lodash';
 import { getMomentTimeUnitForQueryInterval, QueryInterval } from './intervalUtils';
-import { Field, FieldType } from '@grafana/data';
+import { Field, FieldConfig, FieldType } from '@grafana/data';
 // eslint-disable-next-line  no-restricted-imports
 import moment from 'moment';
 import type { DurationInputArg2 } from 'moment/moment';
@@ -116,7 +116,8 @@ export function transformGroupedTimeSeriesData(
   dataRows: MixedDataRowList,
   startTimestamp: number,
   endTimestamp: number,
-  interval: QueryInterval
+  interval: QueryInterval,
+  fieldConfig?: FieldConfig
 ): Array<Partial<Field>> {
   if (dataRows.length === 0) {
     return [];
@@ -165,6 +166,7 @@ export function transformGroupedTimeSeriesData(
       name: name,
       values: valueColumn[0] as NumberDataRow,
       type: FieldType.number,
+      config: fieldConfig ?? {},
     });
   });
 
@@ -186,7 +188,8 @@ export function transformSimpleTimeSeries(
   columnName: string,
   startTimestamp: number,
   endTimestamp: number,
-  interval: QueryInterval
+  interval: QueryInterval,
+  fieldConfig?: FieldConfig
 ): Array<Partial<Field>> {
   if (dataRows.length === 0) {
     return [];
@@ -206,6 +209,7 @@ export function transformSimpleTimeSeries(
     name: columnName,
     values: columns[columns.length - 1] as NumberDataRow,
     type: FieldType.number,
+    config: fieldConfig ?? {},
   });
 
   return fields;
@@ -220,7 +224,8 @@ export function transformSimpleTimeSeries(
  */
 export function transformTableData(
   dataRows: MixedDataRowList,
-  columnLabels: Array<{ key: string; label: string }>
+  columnLabels: Array<{ key: string; label: string }>,
+  fieldConfig?: FieldConfig
 ): Array<Partial<Field>> {
   if (dataRows.length === 0) {
     return [];
@@ -256,6 +261,7 @@ export function transformTableData(
     name: columnNames[columnNames.length - 1],
     values: columns[columns.length - 1] as NumberDataRow,
     type: FieldType.number,
+    config: fieldConfig ?? {},
   });
 
   return fields;

--- a/src/utils/fieldConfig.test.ts
+++ b/src/utils/fieldConfig.test.ts
@@ -1,0 +1,23 @@
+import { inferFieldConfig } from './fieldConfig';
+
+describe('inferFieldConfig', () => {
+  it('returns ms unit for VIDEO_STARTUPTIME', () => {
+    expect(inferFieldConfig('VIDEO_STARTUPTIME')).toEqual({ unit: 'ms' });
+  });
+
+  it('returns percentunit with 2 decimals for REBUFFER_PERCENTAGE', () => {
+    expect(inferFieldConfig('REBUFFER_PERCENTAGE')).toEqual({ unit: 'percentunit', decimals: 2 });
+  });
+
+  it('returns bps unit for DOWNLOAD_SPEED', () => {
+    expect(inferFieldConfig('DOWNLOAD_SPEED')).toEqual({ unit: 'bps' });
+  });
+
+  it('returns empty config for unmapped dimension COUNTRY', () => {
+    expect(inferFieldConfig('COUNTRY')).toEqual({});
+  });
+
+  it('returns empty config for undefined', () => {
+    expect(inferFieldConfig(undefined)).toEqual({});
+  });
+});

--- a/src/utils/fieldConfig.ts
+++ b/src/utils/fieldConfig.ts
@@ -1,0 +1,38 @@
+import { FieldConfig } from '@grafana/data';
+import { QueryAttribute } from '../types/queryAttributes';
+import { QueryAdAttribute } from '../types/queryAdAttributes';
+
+const UNIT_MAP: Partial<Record<QueryAttribute | QueryAdAttribute, string>> = {
+  VIDEO_STARTUPTIME: 'ms',
+  PLAYER_STARTUPTIME: 'ms',
+  DRM_LOAD_TIME: 'ms',
+  BUFFERED: 'ms',
+  PLAYED: 'ms',
+  VIEWTIME: 'ms',
+  SEEKED: 'ms',
+  VIDEO_DURATION: 'ms',
+  DURATION: 'ms',
+  VIDEO_BITRATE: 'bps',
+  AUDIO_BITRATE: 'bps',
+  DOWNLOAD_SPEED: 'bps',
+  VIDEO_SEGMENTS_DOWNLOAD_SIZE: 'bytes',
+  REBUFFER_PERCENTAGE: 'percentunit',
+  ERROR_PERCENTAGE: 'percentunit',
+  AD_STARTUP_TIME: 'ms',
+};
+
+export function inferFieldConfig(
+  dimension: QueryAttribute | QueryAdAttribute | string | undefined
+): FieldConfig {
+  if (!dimension) {
+    return {};
+  }
+  const unit = UNIT_MAP[dimension as QueryAttribute | QueryAdAttribute];
+  if (!unit) {
+    return {};
+  }
+  return {
+    unit,
+    decimals: unit === 'percentunit' ? 2 : undefined,
+  };
+}

--- a/src/utils/fieldTypes.test.ts
+++ b/src/utils/fieldTypes.test.ts
@@ -1,0 +1,27 @@
+import { inferFieldValueType } from './fieldTypes';
+
+describe('inferFieldValueType', () => {
+  it('returns boolean for IS_LIVE', () => {
+    expect(inferFieldValueType('IS_LIVE')).toBe('boolean');
+  });
+
+  it('returns boolean for IS_CASTING', () => {
+    expect(inferFieldValueType('IS_CASTING')).toBe('boolean');
+  });
+
+  it('returns boolean for IS_MUTED', () => {
+    expect(inferFieldValueType('IS_MUTED')).toBe('boolean');
+  });
+
+  it('returns number for VIDEO_STARTUPTIME', () => {
+    expect(inferFieldValueType('VIDEO_STARTUPTIME')).toBe('number');
+  });
+
+  it('returns string for COUNTRY', () => {
+    expect(inferFieldValueType('COUNTRY')).toBe('string');
+  });
+
+  it('returns string for BROWSER', () => {
+    expect(inferFieldValueType('BROWSER')).toBe('string');
+  });
+});

--- a/src/utils/fieldTypes.ts
+++ b/src/utils/fieldTypes.ts
@@ -1,0 +1,28 @@
+import { QueryAttribute } from '../types/queryAttributes';
+import { QueryAdAttribute } from '../types/queryAdAttributes';
+
+export type FieldValueType = 'boolean' | 'number' | 'string';
+
+const BOOLEAN_FIELDS: Array<QueryAttribute | QueryAdAttribute> = [
+  'IS_LIVE', 'IS_CASTING', 'IS_MUTED', 'IS_LINEAR', 'AUTOPLAY', 'BROWSER_IS_BOT',
+];
+
+const NUMBER_FIELDS: Array<QueryAttribute | QueryAdAttribute> = [
+  'AD', 'AD_INDEX', 'AUDIO_BITRATE', 'BUFFERED', 'CLIENT_TIME',
+  'DRM_LOAD_TIME', 'DROPPED_FRAMES', 'DURATION', 'ERROR_CODE',
+  'PAGE_LOAD_TIME', 'PAGE_LOAD_TYPE', 'PAUSED', 'PLAYED',
+  'SCREEN_HEIGHT', 'SCREEN_WIDTH', 'SEEKED', 'VIDEO_BITRATE',
+  'VIDEO_DURATION', 'VIDEO_STARTUPTIME', 'VIEWTIME',
+];
+
+export function inferFieldValueType(
+  attribute: QueryAttribute | QueryAdAttribute
+): FieldValueType {
+  if (BOOLEAN_FIELDS.includes(attribute)) {
+    return 'boolean';
+  }
+  if (NUMBER_FIELDS.includes(attribute)) {
+    return 'number';
+  }
+  return 'string';
+}

--- a/src/utils/filterUtils.test.ts
+++ b/src/utils/filterUtils.test.ts
@@ -1,4 +1,22 @@
-import { convertFilterValueToProperType } from './filterUtils';
+import { convertFilterValueToProperType, normalizeMultiValueFilter } from './filterUtils';
+
+describe('normalizeMultiValueFilter', () => {
+  it('converts Grafana glob format {val1,val2} to JSON array', () => {
+    expect(normalizeMultiValueFilter('{Firefox,Chrome}')).toBe('["Firefox","Chrome"]');
+  });
+
+  it('converts CSV format val1,val2 to JSON array', () => {
+    expect(normalizeMultiValueFilter('Firefox,Chrome')).toBe('["Firefox","Chrome"]');
+  });
+
+  it('passes through an existing JSON array unchanged', () => {
+    expect(normalizeMultiValueFilter('["Firefox","Chrome"]')).toBe('["Firefox","Chrome"]');
+  });
+
+  it('returns a single value unchanged', () => {
+    expect(normalizeMultiValueFilter('Firefox')).toBe('Firefox');
+  });
+});
 
 describe('convertFilterValueToProperType', () => {
   it('should return null if rawValue is empty and attribute a NullFilter', () => {
@@ -12,7 +30,7 @@ describe('convertFilterValueToProperType', () => {
   it('should throw an error if value for IN filter is not a json array', () => {
     //arrange & act && assert
     expect(() => convertFilterValueToProperType('Firefox', 'BROWSER', 'IN', false)).toThrow(
-      new Error('Couldn\'t parse IN filter, please provide data in JSON array form (e.g.: ["Firefox", "Chrome"]).')
+      new Error('Couldn\'t parse IN filter. Provide a JSON array (e.g.: ["Firefox", "Chrome"]) or select multiple values from a Grafana variable.')
     );
   });
 

--- a/src/utils/filterUtils.ts
+++ b/src/utils/filterUtils.ts
@@ -183,6 +183,19 @@ const convertFilter = (rawValue: string, filterAttribute: QueryAttribute) => {
   }
 };
 
+export function normalizeMultiValueFilter(value: string): string {
+  if (value.trimStart().startsWith('[')) {
+    return value;
+  }
+  const globMatch = value.match(/^\{(.+)\}$/);
+  const csv = globMatch ? globMatch[1] : value;
+  const parts = csv.split(',').map((v) => v.trim()).filter(Boolean);
+  if (parts.length > 1) {
+    return JSON.stringify(parts);
+  }
+  return value;
+}
+
 /**
  * Transforms the string filter Value from the UI to the appropriate type for our API.
  *
@@ -204,10 +217,10 @@ export const convertFilterValueToProperType = (
 
   if (filterOperator === 'IN') {
     try {
-      return parseValueForInFilter(rawValue);
+      return parseValueForInFilter(normalizeMultiValueFilter(rawValue));
     } catch (e) {
       throw new Error(
-        'Couldn\'t parse IN filter, please provide data in JSON array form (e.g.: ["Firefox", "Chrome"]).'
+        'Couldn\'t parse IN filter. Provide a JSON array (e.g.: ["Firefox", "Chrome"]) or select multiple values from a Grafana variable.'
       );
     }
   }


### PR DESCRIPTION
## Summary

This PR adds native Grafana template variable support to the Bitmovin Analytics datasource, enabling dynamic, reusable dashboards where filters, aliases, and queries respond to dashboard-level variable selectors.

## Changes

### Session 1 — Template variable interpolation in filters and alias
- Interpolates Grafana template variables (e.g. `$region`, `${region}`) in filter values and metric alias
- Skips filters where the value resolves to the Grafana "All" wildcard (`$__all`), avoiding invalid API requests

### Session 2 — Native Grafana variable queries (metricFindQuery, ad-hoc filters)
- Implements `metricFindQuery` so datasource fields can populate Grafana variable dropdowns
- Implements `getTagKeys` and `getTagValues` for ad-hoc filter support
- Supports multi-value variables using the `IN` operator

### Session 3 — License variable toggle
- Adds a toggle in the query editor to expose the license key as a queryable field
- Adds `licenses` as a supported keyword in `metricFindQuery` to populate license variable dropdowns

### Session 4 — Variable interpolation inside metricFindQuery
- Interpolates dashboard variables inside `metricFindQuery` query strings, enabling chained/dependent variable dropdowns (e.g. a `contentType` variable filtered by the currently selected `$license`)

### Session 5 — Automatic field unit inference
- Infers Grafana field units from the selected Analytics dimension (e.g. `STARTUPTIME` → milliseconds, `REBUFFER_PERCENTAGE` → percent)
- Enables automatic Y-axis labelling in time series panels without manual field config

### Session 6 — Query editor UX improvements
- Replaces free-text inputs for boolean filter values with proper dropdowns (`true`/`false`)
- Adds `IN (...)` placeholder text to multi-value filter inputs for clarity
- Implements `getQueryDisplayText` so saved queries show a human-readable summary in the panel editor

## Files Changed

| Area | Files |
|---|---|
| Datasource logic | `src/datasource.ts`, `src/module.ts` |
| Query editor UI | `src/components/QueryEditor.tsx`, `src/components/QueryFilterInput.tsx`, `src/components/VariableQueryEditor.tsx` |
| Utilities | `src/utils/filterUtils.ts`, `src/utils/fieldConfig.ts`, `src/utils/fieldTypes.ts`, `src/utils/dataUtils.ts` |
| Types | `src/types/grafanaTypes.ts` |
| Tests | `src/datasource.test.ts`, `src/utils/filterUtils.test.ts`, `src/utils/fieldConfig.test.ts`, `src/utils/fieldTypes.test.ts`, `src/utils/dataUtils.test.ts` |

## Compatibility

No breaking changes. All existing dashboards and saved queries continue to work without modification. New features are additive only.

## Testing

All existing and new unit tests pass (`npm test`).