### PR TITLE
add support for template variables for filter, alias and license pickers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Resolve Grafana E2E versions
         id: resolve-versions
-        uses: grafana/plugin-actions/e2e-version@main
+        uses: grafana/plugin-actions/e2e-version@3.8.0s
         with:
           skip-grafana-nightly-image: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Resolve Grafana E2E versions
         id: resolve-versions
-        uses: grafana/plugin-actions/e2e-version@2.0.0
+        uses: grafana/plugin-actions/e2e-version@e2e-version/v2
         with:
           skip-grafana-nightly-image: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Resolve Grafana E2E versions
         id: resolve-versions
-        uses: grafana/plugin-actions/e2e-version@3.8.0s
+        uses: grafana/plugin-actions/e2e-version@2.0.0
         with:
           skip-grafana-nightly-image: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Development
 
+### Added
+
+- grafana template variable support for filter, alias and license selection
+
 ## 1.5.0
 
 ### Added

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -1,5 +1,5 @@
 import React, { ChangeEvent, useEffect, useMemo, useState } from 'react';
-import { FieldSet, HorizontalGroup, InlineField, InlineSwitch, Input, Select } from '@grafana/ui';
+import { Button, FieldSet, HorizontalGroup, InlineField, InlineSwitch, Input, Select } from '@grafana/ui';
 import type { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { defaults } from 'lodash';
 
@@ -66,6 +66,15 @@ export function QueryEditor(props: Props) {
   const handleLicenseChange = (item: SelectableValue) => {
     props.onChange({ ...query, license: item.value });
     props.onRunQuery();
+  };
+
+  const handleLicenseModeToggle = () => {
+    props.onChange({ ...query, useVariableForLicense: !query.useVariableForLicense, license: '' });
+    props.onRunQuery();
+  };
+
+  const handleLicenseVariableChange = (event: ChangeEvent<HTMLInputElement>) => {
+    props.onChange({ ...query, license: event.target.value });
   };
 
   const handleAggregationChange = (item: SelectableValue) => {
@@ -167,21 +176,46 @@ export function QueryEditor(props: Props) {
         <InlineField
           label="License"
           labelWidth={20}
-          invalid={licenseLoadingState === LoadingState.Error}
+          invalid={!query.useVariableForLicense && licenseLoadingState === LoadingState.Error}
           error={`Error when fetching Analytics Licenses: ${licenseErrorMessage}`}
-          disabled={licenseLoadingState === LoadingState.Error}
+          disabled={!query.useVariableForLicense && licenseLoadingState === LoadingState.Error}
           required
         >
-          <Select
-            id={`query-editor-${props.query.refId}_license-select`}
-            value={query.license}
-            onChange={handleLicenseChange}
-            width={30}
-            options={selectableLicenses}
-            noOptionsMessage="No Analytics Licenses found"
-            isLoading={licenseLoadingState === LoadingState.Loading}
-            placeholder={licenseLoadingState === LoadingState.Loading ? 'Loading Licenses' : 'Choose License'}
-          />
+          <HorizontalGroup spacing="xs">
+            {query.useVariableForLicense ? (
+              <Input
+                id={`query-editor-${props.query.refId}_license-variable-input`}
+                value={query.license}
+                onChange={handleLicenseVariableChange}
+                onBlur={() => props.onRunQuery()}
+                width={30}
+                placeholder="${your_license_variable}"
+              />
+            ) : (
+              <Select
+                id={`query-editor-${props.query.refId}_license-select`}
+                value={query.license}
+                onChange={handleLicenseChange}
+                width={30}
+                options={selectableLicenses}
+                noOptionsMessage="No Analytics Licenses found"
+                isLoading={licenseLoadingState === LoadingState.Loading}
+                placeholder={licenseLoadingState === LoadingState.Loading ? 'Loading Licenses' : 'Choose License'}
+              />
+            )}
+            <Button
+              data-testid={`query-editor-${props.query.refId}_license-variable-toggle-button`}
+              variant="secondary"
+              onClick={handleLicenseModeToggle}
+              tooltip={
+                query.useVariableForLicense
+                  ? 'Switch back to picking a license from the list'
+                  : 'Use any dashboard variable for the license, e.g. ${prod_license}'
+              }
+            >
+              {query.useVariableForLicense ? 'Pick license' : 'Use variable'}
+            </Button>
+          </HorizontalGroup>
         </InlineField>
         <HorizontalGroup spacing="xs">
           {!isMetricSelected && (

--- a/src/components/QueryFilterInput.tsx
+++ b/src/components/QueryFilterInput.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { HorizontalGroup, IconButton, Input, Select, Tooltip } from '@grafana/ui';
+import { HorizontalGroup, Icon, IconButton, Input, Select, Tooltip } from '@grafana/ui';
+import { getTemplateSrv } from '@grafana/runtime';
 
 import { QueryFilter, QueryFilterOperator, SELECTABLE_QUERY_FILTER_OPERATORS } from '../types/queryFilter';
 import type { SelectableValue } from '@grafana/data';
@@ -9,7 +10,7 @@ import {
   SELECTABLE_QUERY_FILTER_ATTRIBUTES,
 } from '../types/queryAttributes';
 import { QueryAdAttribute, SELECTABLE_QUERY_AD_ATTRIBUTES } from '../types/queryAdAttributes';
-import { convertFilterValueToProperType } from 'utils/filterUtils';
+import { convertFilterValueToProperType, getMultiValueOperatorWarning, VariableLike } from 'utils/filterUtils';
 
 interface QueryFilterInputProps {
   /** `undefined` when component is used to create new filter (no values yet) */
@@ -44,6 +45,17 @@ export function QueryFilterInput(props: Readonly<QueryFilterInputProps>) {
   const operatorSelectValue = useMemo(
     () => findOperatorSelectableValue(derivedQueryFilterState.operator),
     [derivedQueryFilterState.operator]
+  );
+
+  /** Warn inline when a multi-value variable is used with a non-IN operator (only the first value applies). */
+  const multiValueWarning = useMemo(
+    () =>
+      getMultiValueOperatorWarning(
+        derivedQueryFilterState.value,
+        derivedQueryFilterState.operator,
+        getTemplateSrv().getVariables() as VariableLike[]
+      ),
+    [derivedQueryFilterState.value, derivedQueryFilterState.operator]
   );
 
   function handleAttributeChange(selectedValue: SelectableValue<QueryAttribute | QueryAdAttribute>) {
@@ -165,6 +177,17 @@ export function QueryFilterInput(props: Readonly<QueryFilterInputProps>) {
           width={VALUE_COMPONENT_WIDTH}
         />
       </Tooltip>
+
+      {multiValueWarning != null && (
+        <Tooltip content={multiValueWarning} theme="info">
+          <span
+            data-testid={`query-editor-${props.queryEditorId}_filter-multi-value-warning`}
+            style={{ display: 'inline-flex', color: 'orange', cursor: 'help' }}
+          >
+            <Icon name="exclamation-triangle" size="lg" />
+          </span>
+        </Tooltip>
+      )}
 
       <IconButton
         data-testid={`query-editor-${props.queryEditorId}_filter-delete-button`}

--- a/src/components/VariableQueryEditor.tsx
+++ b/src/components/VariableQueryEditor.tsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+import { InlineField, Input } from '@grafana/ui';
+import type { BitmovinVariableQuery } from '../types/variableQuery';
+
+interface Props {
+  query: BitmovinVariableQuery;
+  onChange: (query: BitmovinVariableQuery) => void;
+}
+
+/**
+ * Editor for "Query" template variables. User can define dimension and license for the query. The query runs when
+ * the user leaves the field or clicks "Run query".
+ */
+export function VariableQueryEditor({ query, onChange }: Props) {
+  const [value, setValue] = useState(query?.query ?? '');
+
+  const commit = () => {
+    if (value !== query?.query) {
+      onChange({ ...query, refId: query?.refId ?? 'BitmovinVariableQuery', query: value });
+    }
+  };
+
+  return (
+    <InlineField
+      label="Query"
+      labelWidth={20}
+      tooltip="e.g. 'dimension:COUNTRY' or 'dimension:BROWSER license:YOUR_LICENSE_KEY'. Without a license the first available one is used. Values are fetched from the last 24 hours."
+      grow
+    >
+      <Input
+        aria-label="Variable query"
+        value={value}
+        placeholder="dimension:COUNTRY or dimension:BROWSER license:YOUR_LICENSE_KEY"
+        onChange={(e) => setValue(e.currentTarget.value)}
+        onBlur={commit}
+      />
+    </InlineField>
+  );
+}

--- a/src/components/VariableQueryEditor.tsx
+++ b/src/components/VariableQueryEditor.tsx
@@ -24,13 +24,13 @@ export function VariableQueryEditor({ query, onChange }: Props) {
     <InlineField
       label="Query"
       labelWidth={20}
-      tooltip="e.g. 'dimension:COUNTRY' or 'dimension:BROWSER license:YOUR_LICENSE_KEY'. Without a license the first available one is used. Values are fetched from the last 24 hours."
+      tooltip="e.g. 'licenses' or 'dimension:COUNTRY' or 'dimension:BROWSER license:YOUR_LICENSE_KEY'. Without a license the first available one is used. Values are fetched from the last 24 hours."
       grow
     >
       <Input
         aria-label="Variable query"
         value={value}
-        placeholder="dimension:COUNTRY or dimension:BROWSER license:YOUR_LICENSE_KEY"
+        placeholder="licenses or dimension:COUNTRY or dimension:BROWSER license:YOUR_LICENSE_KEY"
         onChange={(e) => setValue(e.currentTarget.value)}
         onBlur={commit}
       />

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -187,6 +187,12 @@ export class DataSource extends DataSourceApi<
       // undefined (not '') for an unset alias so Grafana keeps deriving the name from the column.
       const alias = getTemplateSrv().replace(target.alias ?? '', options.scopedVars) || undefined;
 
+      // When the license is provided via a dashboard variable, interpolate it; otherwise it's a
+      // picked license key and is used verbatim.
+      const licenseKey = target.useVariableForLicense
+        ? getTemplateSrv().replace(target.license, options.scopedVars)
+        : target.license;
+
       const query: BitmovinAnalyticsRequestQuery = {
         filters: filters,
         groupBy: target.groupBy,
@@ -195,7 +201,7 @@ export class DataSource extends DataSourceApi<
         metric: metric,
         start: queryFrom.toDate(),
         end: queryTo.toDate(),
-        licenseKey: target.license,
+        licenseKey: licenseKey,
         interval: interval,
         limit: this.parseLimit(target.limit),
         percentile: percentileValue,
@@ -309,6 +315,7 @@ export class DataSource extends DataSourceApi<
 
   /**
    * Populates Grafana "Query" template variables. The query text uses the following syntax:
+   *   `licenses`                               -> the account's licenses (text = name, value = key)
    *   `dimension:COUNTRY`                      -> distinct values of COUNTRY for the first license
    *   `dimension:BROWSER license:<licenseKey>` -> distinct values of BROWSER for a specific license
    *
@@ -322,6 +329,20 @@ export class DataSource extends DataSourceApi<
       ?.trim();
     if (!interpolated) {
       return [];
+    }
+
+    // `licenses` lists the account's licenses (text = name, value = license key) so a variable can
+    // drive the license picker / a `license:${var}` in other variable queries.
+    if (interpolated.toLowerCase() === 'licenses') {
+      try {
+        const response = await lastValueFrom(this.request('/analytics/licenses', 'GET'));
+        const items: Array<{ licenseKey: string; name?: string }> = response.data.data.result?.items ?? [];
+        return items
+          .filter((license) => license.licenseKey != null)
+          .map((license) => ({ text: license.name || license.licenseKey, value: license.licenseKey }));
+      } catch (err) {
+        throw this.toApiError(err, 'Failed to load licenses');
+      }
     }
 
     const dimensionMatch = interpolated.match(/dimension:(\S+)/);

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -9,7 +9,7 @@ import {
   QueryResultMetaNotice,
   RawTimeRange,
 } from '@grafana/data';
-import { getBackendSrv } from '@grafana/runtime';
+import { getBackendSrv, getTemplateSrv } from '@grafana/runtime';
 import { cloneDeep, filter, isEmpty } from 'lodash';
 // eslint-disable-next-line  no-restricted-imports
 import moment from 'moment';
@@ -135,13 +135,48 @@ export class DataSource extends DataSourceApi<
         }
       }
 
-      const filters: ProperTypedQueryFilter[] = target.filter.map((filter) => {
-        return {
-          name: filter.name,
-          operator: filter.operator,
-          value: convertFilterValueToProperType(filter.value, filter.name, filter.operator, !!this.isAdAnalytics),
-        };
-      });
+      const filters: ProperTypedQueryFilter[] = (target.filter ?? [])
+        .map((filterEntry) => {
+          // Capture the resolved values so we can tell a multi-value variable apart from a plain
+          // string. Multi-value variables arrive in the format callback as an array.
+          let multiValues: string[] | undefined;
+          const interpolatedValue = getTemplateSrv().replace(
+            filterEntry.value,
+            options.scopedVars,
+            (value: string | string[]) => {
+              if (Array.isArray(value)) {
+                multiValues = value;
+                return JSON.stringify(value);
+              }
+              return value;
+            }
+          );
+          return { filterEntry, interpolatedValue, multiValues };
+        })
+        // When a multi-value variable is set to "All" with the default all-value, Grafana
+        // interpolates to the "$__all" sentinel. Drop the filter so the query matches all data
+        // instead of filtering on the literal string. Empty values are intentionally NOT dropped:
+        // convertFilterValueToProperType maps them to a null ("IS NULL") filter for the relevant
+        // attributes.
+        .filter(({ interpolatedValue }) => interpolatedValue !== '$__all')
+        .map(({ filterEntry, interpolatedValue, multiValues }) => {
+          let value = interpolatedValue;
+          // A multi-value variable only has a well-defined meaning for the IN operator. For any
+          // other operator we apply just the first selected value so the behaviour is predictable
+          // rather than silently empty. The query editor warns the user about this inline.
+          if (filterEntry.operator !== 'IN' && multiValues !== undefined) {
+            value = multiValues[0] ?? '';
+          }
+          return {
+            name: filterEntry.name,
+            operator: filterEntry.operator,
+            value: convertFilterValueToProperType(value, filterEntry.name, filterEntry.operator, !!this.isAdAnalytics),
+          };
+        });
+
+      // Interpolate the alias so dashboard variables can be used in series names. Fall back to
+      // undefined (not '') for an unset alias so Grafana keeps deriving the name from the column.
+      const alias = getTemplateSrv().replace(target.alias ?? '', options.scopedVars) || undefined;
 
       const query: BitmovinAnalyticsRequestQuery = {
         filters: filters,
@@ -189,18 +224,16 @@ export class DataSource extends DataSourceApi<
         }
       }
 
-      let metaNotices: QueryResultMetaNotice[] = [];
+      const metaNotices: QueryResultMetaNotice[] = [];
       if (dataRowCount >= 200) {
-        metaNotices = [
-          {
-            severity: 'warning',
-            text: 'Your request reached the max row limit of the API. You might see incomplete data. This problem might be caused by the use of high cardinality columns in group by, too small interval, or too big of a time range.',
-          },
-        ];
+        metaNotices.push({
+          severity: 'warning',
+          text: 'Your request reached the max row limit of the API. You might see incomplete data. This problem might be caused by the use of high cardinality columns in group by, too small interval, or too big of a time range.',
+        });
       }
 
       return createDataFrame({
-        name: target.alias,
+        name: alias,
         fields: fields,
         meta: { notices: metaNotices },
       });

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -1,19 +1,23 @@
 import {
   CoreApp,
   createDataFrame,
+  CustomVariableSupport,
   DataQueryRequest,
   DataQueryResponse,
   DataSourceApi,
   DataSourceInstanceSettings,
   Field,
+  FieldType,
+  MetricFindValue,
   QueryResultMetaNotice,
   RawTimeRange,
+  ScopedVars,
 } from '@grafana/data';
 import { getBackendSrv, getTemplateSrv } from '@grafana/runtime';
 import { cloneDeep, filter, isEmpty } from 'lodash';
 // eslint-disable-next-line  no-restricted-imports
 import moment from 'moment';
-import { catchError, lastValueFrom, map, Observable, of } from 'rxjs';
+import { catchError, from, lastValueFrom, map, Observable, of } from 'rxjs';
 
 import {
   BitmovinAnalyticsDataQuery,
@@ -41,6 +45,8 @@ import { QueryAttribute } from './types/queryAttributes';
 import { QueryAdAttribute } from './types/queryAdAttributes';
 import { QueryOrderBy } from './types/queryOrderBy';
 import { convertFilterValueToProperType } from './utils/filterUtils';
+import { VariableQueryEditor } from './components/VariableQueryEditor';
+import { BitmovinVariableQuery } from './types/variableQuery';
 
 type BitmovinAnalyticsRequestQuery = {
   licenseKey: string;
@@ -72,6 +78,9 @@ export class DataSource extends DataSourceApi<
     this.tenantOrgId = instanceSettings.jsonData.tenantOrgId;
     this.isAdAnalytics = instanceSettings.jsonData.isAdAnalytics;
     this.baseUrl = instanceSettings.url!;
+
+    // Enables "Query" template variables backed by this datasource (see metricFindQuery).
+    this.variables = new BitmovinVariableSupport(this);
   }
 
   getDefaultQuery(_: CoreApp): Partial<BitmovinAnalyticsDataQuery> {
@@ -298,6 +307,100 @@ export class DataSource extends DataSourceApi<
     return url + '/queries/' + aggregation;
   }
 
+  /**
+   * Populates Grafana "Query" template variables. The query text uses the following syntax:
+   *   `dimension:COUNTRY`                      -> distinct values of COUNTRY for the first license
+   *   `dimension:BROWSER license:<licenseKey>` -> distinct values of BROWSER for a specific license
+   *
+   * Template variables in the query text are interpolated first, so one variable can feed another
+   * (e.g. `dimension:COUNTRY license:${licenseVar}`).
+   * When no `license:` is given the first available license is used.
+   */
+  async metricFindQuery(query: string, options?: { scopedVars?: ScopedVars }): Promise<MetricFindValue[]> {
+    const interpolated = getTemplateSrv()
+      .replace(query ?? '', options?.scopedVars)
+      ?.trim();
+    if (!interpolated) {
+      return [];
+    }
+
+    const dimensionMatch = interpolated.match(/dimension:(\S+)/);
+    if (!dimensionMatch) {
+      return [];
+    }
+    const dimension = dimensionMatch[1] as QueryAttribute;
+
+    const rawLicenseKey = interpolated.match(/license:(\S+)/)?.[1];
+    let licenseKey: string | undefined;
+    if (rawLicenseKey != null) {
+      // An explicit license was requested. If it's an unresolved variable reference, surface an error.
+      if (this.isUnresolvedVariable(rawLicenseKey)) {
+        throw new Error(
+          `Could not resolve the license in the variable query ("${rawLicenseKey}"). Make sure the referenced dashboard variable exists and has a value.`
+        );
+      }
+      licenseKey = rawLicenseKey;
+    } else {
+      // No license given: fall back to the first available license.
+      licenseKey = await this.getFirstLicenseKey();
+    }
+    if (!licenseKey) {
+      return [];
+    }
+
+    // query a fixed 24h worth of data
+    const end = new Date();
+    const start = new Date(end.getTime() - 24 * 60 * 60 * 1000);
+
+    const requestQuery = {
+      licenseKey,
+      start,
+      end,
+      // Count distinct values of `dimension` by grouping a count aggregation over impressions.
+      dimension: 'IMPRESSION_ID' as QueryAttribute,
+      groupBy: [dimension],
+      orderBy: [],
+      filters: [],
+    };
+
+    try {
+      const response = await lastValueFrom(this.request('/analytics/queries/count', 'POST', requestQuery));
+      const rows: MixedDataRowList = response.data.data.result?.rows ?? [];
+      return rows
+        .map((row) => row[0])
+        .filter((value) => value != null && value !== '')
+        .map((value) => ({ text: String(value), value: String(value) }));
+    } catch (err) {
+      // Surface the failure in the variable editor instead of silently returning no options.
+      throw this.toApiError(err, 'Failed to load variable values');
+    }
+  }
+
+  /**
+   * Returns true if `getTemplateSrv().replace` left an unresolved variable reference in place
+   * (`${var}`, `$var` or `[[var]]`).
+   */
+  private isUnresolvedVariable(value: string): boolean {
+    return /\$\{?\w+\}?|\[\[\w+\]\]/.test(value);
+  }
+
+  private async getFirstLicenseKey(): Promise<string | undefined> {
+    try {
+      const response = await lastValueFrom(this.request('/analytics/licenses', 'GET'));
+      return response.data.data.result?.items?.[0]?.licenseKey;
+    } catch (err) {
+      throw this.toApiError(err, 'Failed to load licenses');
+    }
+  }
+
+  /** Builds a readable Error from a Bitmovin API failure so it can be shown to the user. */
+  private toApiError(err: unknown, context: string): Error {
+    const e = err as { status?: number; statusText?: string; data?: { message?: string; data?: { message?: string } } };
+    const detail = e?.data?.message ?? e?.data?.data?.message ?? e?.statusText ?? 'request failed';
+    const status = e?.status ? `${e.status} ` : '';
+    return new Error(`${context}: ${status}${detail}`);
+  }
+
   request(url: string, method: string, payload?: any): Observable<Record<any, any>> {
     const headers: Record<string, string> = {
       'X-Api-Key': this.apiKey,
@@ -352,6 +455,38 @@ export class DataSource extends DataSourceApi<
           });
         })
       )
+    );
+  }
+}
+
+/**
+ * Variable support for "Query" template variables. Delegates to {@link DataSource.metricFindQuery}
+ * and wraps the result in a data frame with `text`/`value` fields, which Grafana turns into the
+ * variable's dropdown options.
+ */
+export class BitmovinVariableSupport extends CustomVariableSupport<DataSource, BitmovinVariableQuery> {
+  constructor(private readonly datasource: DataSource) {
+    super();
+    // Bind so the method keeps its `this` when Grafana invokes it detached.
+    this.query = this.query.bind(this);
+  }
+
+  editor = VariableQueryEditor;
+
+  query(request: DataQueryRequest<BitmovinVariableQuery>): Observable<DataQueryResponse> {
+    const queryText = request.targets[0]?.query ?? '';
+
+    return from(this.datasource.metricFindQuery(queryText, { scopedVars: request.scopedVars })).pipe(
+      map((values) => ({
+        data: [
+          createDataFrame({
+            fields: [
+              { name: 'text', type: FieldType.string, values: values.map((v) => String(v.text)) },
+              { name: 'value', type: FieldType.string, values: values.map((v) => String(v.value ?? v.text)) },
+            ],
+          }),
+        ],
+      }))
     );
   }
 }

--- a/src/types/grafanaTypes.ts
+++ b/src/types/grafanaTypes.ts
@@ -15,6 +15,9 @@ type ResultFormat = 'table' | 'time_series';
  * */
 export interface BitmovinAnalyticsDataQuery extends DataQuery {
   license: string;
+  /** When true, `license` holds a dashboard-variable expression (e.g. `${licenseVar}`) that is
+   * interpolated at query time instead of being a picked license key. */
+  useVariableForLicense?: boolean;
   interval?: QueryInterval | 'AUTO';
   metric?: AggregationMethod;
   dimension?: QueryAttribute | QueryAdAttribute | Metric;

--- a/src/types/variableQuery.ts
+++ b/src/types/variableQuery.ts
@@ -1,0 +1,7 @@
+import { DataQuery } from '@grafana/schema';
+
+/** Query model for "Query" template variables backed by this datasource. */
+export interface BitmovinVariableQuery extends DataQuery {
+  /** Raw query text, e.g. `dimension:COUNTRY` or `dimension:BROWSER license:YOUR_LICENSE_KEY`. */
+  query: string;
+}

--- a/src/utils/filterUtils.test.ts
+++ b/src/utils/filterUtils.test.ts
@@ -1,4 +1,31 @@
-import { convertFilterValueToProperType } from './filterUtils';
+import {
+  convertFilterValueToProperType,
+  getMultiValueOperatorWarning,
+  normalizeInFilterValue,
+  VariableLike,
+} from './filterUtils';
+
+describe('normalizeInFilterValue', () => {
+  it('passes an explicit JSON array through unchanged', () => {
+    expect(normalizeInFilterValue('["Firefox","Chrome"]')).toBe('["Firefox","Chrome"]');
+  });
+
+  it('converts a Grafana multi-value glob to a JSON array', () => {
+    expect(normalizeInFilterValue('{Firefox,Chrome}')).toBe('["Firefox","Chrome"]');
+  });
+
+  it('converts a comma separated list to a JSON array', () => {
+    expect(normalizeInFilterValue('Firefox, Chrome')).toBe('["Firefox","Chrome"]');
+  });
+
+  it('wraps a single value into a one-element array', () => {
+    expect(normalizeInFilterValue('Firefox')).toBe('["Firefox"]');
+  });
+
+  it('returns an empty array for an empty string', () => {
+    expect(normalizeInFilterValue('')).toBe('[]');
+  });
+});
 
 describe('convertFilterValueToProperType', () => {
   it('should return null if rawValue is empty and attribute a NullFilter', () => {
@@ -9,10 +36,36 @@ describe('convertFilterValueToProperType', () => {
     expect(result).toBeNull();
   });
 
-  it('should throw an error if value for IN filter is not a json array', () => {
+  it('should normalize a single value into a one-element array for IN filter', () => {
+    //arrange & act
+    const result = convertFilterValueToProperType('Firefox', 'BROWSER', 'IN', false);
+
+    //assert
+    expect(result).toEqual(['Firefox']);
+  });
+
+  it('should normalize a Grafana multi-value glob into an array for IN filter', () => {
+    //arrange & act
+    const result = convertFilterValueToProperType('{Firefox,Chrome}', 'BROWSER', 'IN', false);
+
+    //assert
+    expect(result).toEqual(['Firefox', 'Chrome']);
+  });
+
+  it('should normalize a comma separated list into an array for IN filter', () => {
+    //arrange & act
+    const result = convertFilterValueToProperType('Firefox,Chrome', 'BROWSER', 'IN', false);
+
+    //assert
+    expect(result).toEqual(['Firefox', 'Chrome']);
+  });
+
+  it('should throw an error if value for IN filter is a malformed JSON array', () => {
     //arrange & act && assert
-    expect(() => convertFilterValueToProperType('Firefox', 'BROWSER', 'IN', false)).toThrow(
-      new Error('Couldn\'t parse IN filter, please provide data in JSON array form (e.g.: ["Firefox", "Chrome"]).')
+    expect(() => convertFilterValueToProperType('["Firefox"', 'BROWSER', 'IN', false)).toThrow(
+      new Error(
+        'Couldn\'t parse IN filter. Provide a JSON array (e.g.: ["Firefox", "Chrome"]) or select values from a multi-value Grafana variable.'
+      )
     );
   });
 
@@ -98,5 +151,39 @@ describe('convertFilterValueToProperType', () => {
     expect(() => convertFilterValueToProperType('two', 'ERROR_PERCENTAGE', 'EQ', false)).toThrow(
       new Error(`Couldn't parse filter value, please provide data as a floating point number`)
     );
+  });
+});
+
+describe('getMultiValueOperatorWarning', () => {
+  const multiVar: VariableLike = { name: 'browsers', multi: true };
+  const singleValueVar: VariableLike = { name: 'country', multi: false };
+
+  it('warns for a non-IN operator referencing a multi-value variable (${name} syntax)', () => {
+    expect(getMultiValueOperatorWarning('${browsers}', 'EQ', [multiVar])).toContain('IN');
+  });
+
+  it('warns for the $name syntax too', () => {
+    expect(getMultiValueOperatorWarning('$browsers', 'NE', [multiVar])).toContain('IN');
+  });
+
+  it('does not warn for the IN operator', () => {
+    expect(getMultiValueOperatorWarning('${browsers}', 'IN', [multiVar])).toBeUndefined();
+  });
+
+  it('does not warn for a single-value (non-multi) variable', () => {
+    expect(getMultiValueOperatorWarning('${country}', 'EQ', [singleValueVar])).toBeUndefined();
+  });
+
+  it('does not warn for a literal value with no variable', () => {
+    expect(getMultiValueOperatorWarning('Firefox', 'EQ', [multiVar])).toBeUndefined();
+  });
+
+  it('does not warn when the referenced variable is not defined', () => {
+    expect(getMultiValueOperatorWarning('${unknown}', 'EQ', [multiVar])).toBeUndefined();
+  });
+
+  it('returns undefined for an empty value or missing operator', () => {
+    expect(getMultiValueOperatorWarning('', 'EQ', [multiVar])).toBeUndefined();
+    expect(getMultiValueOperatorWarning('${browsers}', undefined, [multiVar])).toBeUndefined();
   });
 });

--- a/src/utils/filterUtils.ts
+++ b/src/utils/filterUtils.ts
@@ -79,6 +79,34 @@ const parseValueForInFilter = (rawValue: string) => {
   return value;
 };
 
+/**
+ * Normalises the raw value of an `IN` filter into a JSON array string that
+ * {@link parseValueForInFilter} can parse.
+ *
+ * Accepts the three shapes an `IN` value can arrive in:
+ * - an explicit JSON array typed by the user: `["Firefox","Chrome"]` (passed through unchanged)
+ * - a Grafana multi-value variable glob: `{Firefox,Chrome}`
+ * - a comma separated list or a single value (e.g. when a multi-value variable resolves to a
+ *   single selection): `Firefox,Chrome` or `Firefox`
+ *
+ * A single value is wrapped into a one-element array so a one-item variable selection
+ * stays a valid `IN` filter instead of throwing.
+ */
+export function normalizeInFilterValue(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.startsWith('[')) {
+    // Already a JSON array (user-typed or produced by the multi-value format callback).
+    return trimmed;
+  }
+  // Strip Grafana's multi-value glob braces ({a,b,c}) if present, then split on commas.
+  const inner = trimmed.replace(/^\{(.*)\}$/, '$1');
+  const parts = inner
+    .split(',')
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+  return JSON.stringify(parts);
+}
+
 const convertFilterForAds = (rawValue: string, filterAttribute: QueryAdAttribute) => {
   switch (filterAttribute) {
     case 'IS_LINEAR':
@@ -204,10 +232,10 @@ export const convertFilterValueToProperType = (
 
   if (filterOperator === 'IN') {
     try {
-      return parseValueForInFilter(rawValue);
+      return parseValueForInFilter(normalizeInFilterValue(rawValue));
     } catch (e) {
       throw new Error(
-        'Couldn\'t parse IN filter, please provide data in JSON array form (e.g.: ["Firefox", "Chrome"]).'
+        `Couldn't parse IN filter. Provide a JSON array (e.g.: ["Firefox", "Chrome"]) or select values from a multi-value Grafana variable.`
       );
     }
   }
@@ -217,3 +245,36 @@ export const convertFilterValueToProperType = (
   }
   return convertFilter(rawValue, filterAttribute as QueryAttribute);
 };
+
+/** Minimal shape of a Grafana template variable needed for the multi-value check. */
+export interface VariableLike {
+  name: string;
+  /** True for variables configured to allow selecting multiple values. */
+  multi?: boolean;
+}
+
+const MULTI_VALUE_WARNING =
+  'This is a multi-value variable but the operator is not "IN". Only the first selected value will be applied — use the "IN" operator to match all selected values.';
+
+/**
+ * Returns a warning when a non-IN filter references a multi-value variable, otherwise `undefined`.
+ * A multi-value variable can resolve to several values, but the Bitmovin API only accepts a single
+ * value for non-IN operators (only the first selected value is applied at query time) — this
+ * surfaces that in the query editor. The warning is shown for any multi-value variable, regardless
+ * of how many values are currently selected (a multi-value variable's value is always an array).
+ */
+export function getMultiValueOperatorWarning(
+  value: string | undefined,
+  operator: QueryFilterOperator | undefined,
+  variables: VariableLike[]
+): string | undefined {
+  if (!value || !operator || operator === 'IN') {
+    return undefined;
+  }
+
+  const usesMultiValueVariable = variables.some(
+    (v) => v.multi === true && (value.includes(`$${v.name}`) || value.includes(`\${${v.name}}`))
+  );
+
+  return usesMultiValueVariable ? MULTI_VALUE_WARNING : undefined;
+}


### PR DESCRIPTION
Ticket: https://bitmovin.atlassian.net/browse/AN-5483

This PR adds native Grafana template variable support to the Bitmovin Analytics datasource, enabling dynamic, reusable dashboards where filters, aliases, and licenses respond to dashboard-level variable selectors. 