### PR TITLE
Fix e2e query editor locators for Grafana 13.1.1

### DIFF
--- a/e2e/queryEditor.spec.ts
+++ b/e2e/queryEditor.spec.ts
@@ -70,38 +70,42 @@ test('should trigger correct number of queries with correct payload', async ({
   await page.getByText('Last 3 hours').click();
 
   // select license
-  await page.locator('#query-editor-A_license-select').click();
+  await page.locator('div#query-editor-A_license-select').click();
   await page.getByText('First Test License', { exact: true }).click();
 
   // select aggregation method
-  await page.locator('#query-editor-A_aggregation-method-select').click();
+  await page.locator('div#query-editor-A_aggregation-method-select').click();
   await page.getByText('count', { exact: true }).click();
 
   // select dimension
-  await page.locator('#query-editor-A_dimension-select').click();
+  await page.locator('div#query-editor-A_dimension-select').click();
   await page.getByText('IMPRESSION_ID', { exact: true }).click(); // request triggered
 
   // add filter
   await page.getByTestId('query-editor-A_add-new-filter-button').click();
-  await page.locator('#query-editor-A_filter-attribute-select').click();
+  await page.locator('div#query-editor-A_filter-attribute-select').click();
   await page.getByText('VIDEO_STARTUPTIME', { exact: true }).click();
-  await page.locator('#query-editor-A_filter-operator-select').click();
+  await page.locator('div#query-editor-A_filter-operator-select').click();
   await page.getByText('GT', { exact: true }).click();
   await page.getByTestId('query-editor-A_filter-value-input').fill('0');
   await page.getByTestId('query-editor-A_filter-save-button').click(); // request triggered
 
   // add group by
   await page.getByTestId('query-editor-A_add-group-by-button').click(); // request triggered
-  await page.locator('#query-editor-A_group-by-select').click();
+  await page.locator('div#query-editor-A_group-by-select').click();
   await page.getByText('BROWSER', { exact: true }).click(); // request triggered
 
   // add order by
   await page.getByTestId('query-editor-A_add-order-by-button').click(); // request triggered
-  await page.locator('#query-editor-A_order-by-select').click();
+  await page.locator('div#query-editor-A_order-by-select').click();
   await page.getByText('FUNCTION', { exact: true }).click(); // request triggered
   // The actual button element is not in the right place to be clicked (because of grafana ui library magic), that's why the
   // sibling label element ('+ label') is fetched and clicked here
-  await page.locator('#option-DESC-query-editor-A_order-by-button-group').locator('+ label').click({ force: true });
+  await page
+    .locator('input[name="query-editor-A_order-by-button-group"]')
+    .nth(1)
+    .locator('+ label')
+    .click({ force: true });
 
   // add limit
   await page.getByTestId('query-editor-A_limit-input').fill('10');
@@ -154,16 +158,16 @@ test('should send correct query if a metric was selected', async ({
   await page.getByText('Last 3 hours').click();
 
   // select license
-  await page.locator('#query-editor-A_license-select').click();
+  await page.locator('div#query-editor-A_license-select').click();
   await page.getByText('First Test License', { exact: true }).click();
 
   // select dimension
   const queryRequestPromise = page.waitForRequest('*/**/analytics/metrics/AVG_CONCURRENTVIEWERS');
-  await page.locator('#query-editor-A_dimension-select').click();
+  await page.locator('div#query-editor-A_dimension-select').click();
   await page.getByText('AVG_CONCURRENTVIEWERS', { exact: true }).click(); // request triggered
 
   // check that aggregation method selection is not visible
-  await expect(page.locator('#query-editor-A_aggregation-method-select')).toHaveCount(0);
+  await expect(page.locator('div#query-editor-A_aggregation-method-select')).toHaveCount(0);
 
   // check for right values in request Payload
   const queryRequest = await queryRequestPromise;
@@ -203,15 +207,15 @@ test('should send correct query for time series and table data', async ({
   await page.getByText('Last 3 hours').click();
 
   // select license
-  await page.locator('#query-editor-A_license-select').click();
+  await page.locator('div#query-editor-A_license-select').click();
   await page.getByText('First Test License', { exact: true }).click();
 
   // select aggregation method
-  await page.locator('#query-editor-A_aggregation-method-select').click();
+  await page.locator('div#query-editor-A_aggregation-method-select').click();
   await page.getByText('count', { exact: true }).click();
 
   // select dimension
-  await page.locator('#query-editor-A_dimension-select').click();
+  await page.locator('div#query-editor-A_dimension-select').click();
   const queryTimeSeriesPromise = page.waitForRequest('*/**/analytics/queries/count');
   await page.getByText('IMPRESSION_ID', { exact: true }).click(); // request triggered
   const queryTimeSeriesRequest = await queryTimeSeriesPromise;
@@ -225,7 +229,7 @@ test('should send correct query for time series and table data', async ({
   // parent element ('..') is fetched here
   await page.getByTestId('query-editor-A_format-as-time-series-switch').locator('..').click(); // request triggered
   // check that interval selection is not visible anymore
-  await expect(page.locator('#query-editor-A_interval-select')).toHaveCount(0);
+  await expect(page.locator('div#query-editor-A_interval-select')).toHaveCount(0);
   const queryTableRequest = await queryTablePromise;
   // check that interval is not set in request
   expect(queryTableRequest.postDataJSON().interval).toBeUndefined();
@@ -233,7 +237,7 @@ test('should send correct query for time series and table data', async ({
   // check format as time series option and select DAY interval
   await page.getByTestId('query-editor-A_format-as-time-series-switch').locator('..').click(); // request triggered
   const queryTimeSeriesDayPromise = page.waitForRequest('*/**/analytics/queries/count');
-  await page.locator('#query-editor-A_interval-select').click();
+  await page.locator('div#query-editor-A_interval-select').click();
   await page.getByText('Day', { exact: true }).click(); // request triggered
   const queryTimeSeriesDayRequest = await queryTimeSeriesDayPromise;
   // check that correct interval is set in request
@@ -262,15 +266,15 @@ test('should send correct query for percentile selection', async ({
   await page.getByText('Last 3 hours').click();
 
   // select license
-  await page.locator('#query-editor-A_license-select').click();
+  await page.locator('div#query-editor-A_license-select').click();
   await page.getByText('First Test License', { exact: true }).click();
 
   // select dimension
-  await page.locator('#query-editor-A_dimension-select').click();
+  await page.locator('div#query-editor-A_dimension-select').click();
   await page.getByText('IMPRESSION_ID', { exact: true }).click();
 
   // select percentile aggregation && add percentile value
-  await page.locator('#query-editor-A_aggregation-method-select').click(); // request triggered
+  await page.locator('div#query-editor-A_aggregation-method-select').click(); // request triggered
   await page.getByText('percentile', { exact: true }).click();
   await page.getByTestId('query-editor-A_percentile-value-input').fill('50'); // request triggered
   const queryPromise = page.waitForRequest('*/**/analytics/queries/percentile');
@@ -308,15 +312,15 @@ test('should add, edit and delete filters correctly', async ({
   const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
   await panelEditPage.datasource.set(ds.name);
   // select license
-  await page.locator('#query-editor-A_license-select').click();
+  await page.locator('div#query-editor-A_license-select').click();
   await page.getByText('First Test License', { exact: true }).click();
 
   // select aggregation method
-  await page.locator('#query-editor-A_aggregation-method-select').click();
+  await page.locator('div#query-editor-A_aggregation-method-select').click();
   await page.getByText('count', { exact: true }).click();
 
   // select dimension
-  await page.locator('#query-editor-A_dimension-select').click();
+  await page.locator('div#query-editor-A_dimension-select').click();
   await page.getByText('IMPRESSION_ID', { exact: true }).click(); // request triggered
 
   //#region add new filters
@@ -325,9 +329,9 @@ test('should add, edit and delete filters correctly', async ({
   await expect(page.getByTestId('query-editor-A_add-new-filter-button')).toHaveCount(0);
 
   // add first filter
-  await page.locator('#query-editor-A_filter-attribute-select').click();
+  await page.locator('div#query-editor-A_filter-attribute-select').click();
   await page.getByText('VIDEO_STARTUPTIME', { exact: true }).click();
-  await page.locator('#query-editor-A_filter-operator-select').click();
+  await page.locator('div#query-editor-A_filter-operator-select').click();
   await page.getByText('GT', { exact: true }).click();
   await page.getByTestId('query-editor-A_filter-value-input').fill('INVALID');
   // check that no query was sent with invalid filter value
@@ -341,9 +345,9 @@ test('should add, edit and delete filters correctly', async ({
 
   // add second filter
   await page.getByTestId('query-editor-A_add-new-filter-button').click();
-  await page.locator('#query-editor-A_filter-attribute-select').nth(1).click();
+  await page.locator('div#query-editor-A_filter-attribute-select').nth(1).click();
   await page.getByText('BROWSER', { exact: true }).click();
-  await page.locator('#query-editor-A_filter-operator-select').nth(1).click();
+  await page.locator('div#query-editor-A_filter-operator-select').nth(1).click();
   await page.getByText('EQ', { exact: true }).click();
   await page.getByTestId('query-editor-A_filter-value-input').nth(1).fill('FIREFOX');
   const queryPromise2 = page.waitForRequest('*/**/analytics/queries/count');
@@ -359,13 +363,13 @@ test('should add, edit and delete filters correctly', async ({
   await expect(page.getByTestId('query-editor-A_filter-save-button')).toHaveCount(0);
 
   // edit first filter and revert changes
-  await page.locator('#query-editor-A_filter-operator-select').first().click();
+  await page.locator('div#query-editor-A_filter-operator-select').first().click();
   await page.getByText('GTE', { exact: true }).click();
   // check that save filter button is visible again
   await expect(page.getByTestId('query-editor-A_filter-save-button')).toHaveCount(1);
   // revert changes
   await page.getByTestId('query-editor-A_filter-revert-changes-button').click();
-  await expect(page.locator('#query-editor-A_filter-operator-select').first()).toHaveText('GT');
+  await expect(page.locator('div#query-editor-A_filter-operator-select').first()).toHaveText('GT');
   // check that revert changes button and save button are not visible
   await expect(page.getByTestId('query-editor-A_filter-revert-changes-button')).toHaveCount(0);
   await expect(page.getByTestId('query-editor-A_filter-save-button')).toHaveCount(0);
@@ -406,23 +410,23 @@ test('should add, edit and delete groupBys correctly', async ({
   await panelEditPage.datasource.set(ds.name);
 
   // select license
-  await page.locator('#query-editor-A_license-select').click();
+  await page.locator('div#query-editor-A_license-select').click();
   await page.getByText('First Test License', { exact: true }).click();
 
   // select aggregation method
-  await page.locator('#query-editor-A_aggregation-method-select').click();
+  await page.locator('div#query-editor-A_aggregation-method-select').click();
   await page.getByText('count', { exact: true }).click();
 
   // select dimension
-  await page.locator('#query-editor-A_dimension-select').click();
+  await page.locator('div#query-editor-A_dimension-select').click();
   await page.getByText('IMPRESSION_ID', { exact: true }).click(); // request triggered
 
   // add 2 group bys
   await page.getByTestId('query-editor-A_add-group-by-button').click(); // request triggered
-  await page.locator('#query-editor-A_group-by-select').click();
+  await page.locator('div#query-editor-A_group-by-select').click();
   await page.getByText('COUNTRY', { exact: true }).click(); // request triggered
   await page.getByTestId('query-editor-A_add-group-by-button').click(); // request triggered
-  await page.locator('#query-editor-A_group-by-select').nth(1).click();
+  await page.locator('div#query-editor-A_group-by-select').nth(1).click();
   const queryPromise1 = page.waitForRequest('*/**/analytics/queries/count');
   await page.getByText('BROWSER', { exact: true }).click(); // request triggered
   const queryRequest1 = await queryPromise1;
@@ -466,23 +470,23 @@ test('should add, edit and delete orderBys correctly', async ({
   await panelEditPage.datasource.set(ds.name);
 
   // select license
-  await page.locator('#query-editor-A_license-select').click();
+  await page.locator('div#query-editor-A_license-select').click();
   await page.getByText('First Test License', { exact: true }).click();
 
   // select aggregation method
-  await page.locator('#query-editor-A_aggregation-method-select').click();
+  await page.locator('div#query-editor-A_aggregation-method-select').click();
   await page.getByText('count', { exact: true }).click();
 
   // select dimension
-  await page.locator('#query-editor-A_dimension-select').click();
+  await page.locator('div#query-editor-A_dimension-select').click();
   await page.getByText('IMPRESSION_ID', { exact: true }).click(); // request triggered
 
   // add 2 order bys
   await page.getByTestId('query-editor-A_add-order-by-button').click(); // request triggered
-  await page.locator('#query-editor-A_order-by-select').click();
+  await page.locator('div#query-editor-A_order-by-select').click();
   await page.getByText('COUNTRY', { exact: true }).click(); // request triggered
   await page.getByTestId('query-editor-A_add-order-by-button').click(); // request triggered
-  await page.locator('#query-editor-A_order-by-select').nth(1).click();
+  await page.locator('div#query-editor-A_order-by-select').nth(1).click();
   const queryPromise1 = page.waitForRequest('*/**/analytics/queries/count');
   await page.getByText('BROWSER', { exact: true }).click(); // request triggered
   const queryRequest1 = await queryPromise1;
@@ -554,11 +558,11 @@ test('should transform and display fetched table data correctly', async ({
   await panelEditPage.setVisualization('Table');
 
   // select license
-  await page.locator('#query-editor-A_license-select').click();
+  await page.locator('div#query-editor-A_license-select').click();
   await page.getByText('First Test License', { exact: true }).click();
 
   // select aggregation method
-  await page.locator('#query-editor-A_aggregation-method-select').click();
+  await page.locator('div#query-editor-A_aggregation-method-select').click();
   await page.getByText('count', { exact: true }).click();
 
   // The actual input switch element is not in the viewport (because of grafana ui library magic), that's why the
@@ -566,7 +570,7 @@ test('should transform and display fetched table data correctly', async ({
   await page.getByTestId('query-editor-A_format-as-time-series-switch').locator('..').click();
 
   // select dimension
-  await page.locator('#query-editor-A_dimension-select').click();
+  await page.locator('div#query-editor-A_dimension-select').click();
   await page.getByText('IMPRESSION_ID', { exact: true }).click(); // request triggered
 
   // assert that data is complete and displayed in the right order
@@ -637,24 +641,24 @@ test('should transform and display fetched timeseries data correctly', async ({
   await page.getByText('Last 3 hours').click();
 
   // select license
-  await page.locator('#query-editor-A_license-select').click();
+  await page.locator('div#query-editor-A_license-select').click();
   await page.getByText('First Test License', { exact: true }).click();
 
   // select aggregation method
-  await page.locator('#query-editor-A_aggregation-method-select').click();
+  await page.locator('div#query-editor-A_aggregation-method-select').click();
   await page.getByText('count', { exact: true }).click();
 
   // select group by
   await page.getByTestId('query-editor-A_add-group-by-button').click();
-  await page.locator('#query-editor-A_group-by-select').click();
+  await page.locator('div#query-editor-A_group-by-select').click();
   await page.getByText('BROWSER', { exact: true }).click();
 
   // select interval
-  await page.locator('#query-editor-A_interval-select').click();
+  await page.locator('div#query-editor-A_interval-select').click();
   await page.getByText('Hour', { exact: true }).click();
 
   // select dimension
-  await page.locator('#query-editor-A_dimension-select').click();
+  await page.locator('div#query-editor-A_dimension-select').click();
   await page.getByText('IMPRESSION_ID', { exact: true }).click(); // request triggered
 
   // assert that data is complete and displayed in the right order
@@ -685,10 +689,10 @@ test('should send the license from the variable input when the toggle is enabled
   await page.locator('#query-editor-A_license-variable-input').fill('my-variable-license');
 
   // Complete the query so it fires.
-  await page.locator('#query-editor-A_aggregation-method-select').click();
+  await page.locator('div#query-editor-A_aggregation-method-select').click();
   await page.getByText('count', { exact: true }).click();
   const countRequestPromise = page.waitForRequest('*/**/analytics/queries/count');
-  await page.locator('#query-editor-A_dimension-select').click();
+  await page.locator('div#query-editor-A_dimension-select').click();
   await page.getByText('IMPRESSION_ID', { exact: true }).click();
   const countRequest = await countRequestPromise;
 
@@ -706,7 +710,7 @@ test('should clear the license when toggling between picker and variable mode', 
   await panelEditPage.datasource.set(ds.name);
 
   // Pick a license from the dropdown.
-  await page.locator('#query-editor-A_license-select').click();
+  await page.locator('div#query-editor-A_license-select').click();
   await page.getByText('First Test License', { exact: true }).click();
 
   // Toggle to variable mode: the input starts blank — the picked key is not carried over.
@@ -716,7 +720,7 @@ test('should clear the license when toggling between picker and variable mode', 
   // Type a variable, toggle back to the picker: the dropdown is blank again, not the typed value.
   await page.locator('#query-editor-A_license-variable-input').fill('${prod_license}');
   await page.getByTestId('query-editor-A_license-variable-toggle-button').click();
-  await expect(page.locator('#query-editor-A_license-select')).not.toContainText('${prod_license}');
+  await expect(page.locator('div#query-editor-A_license-select')).not.toContainText('${prod_license}');
 });
 
 test('should interpolate single- and multi-value dashboard variables in filter values and license input', async ({


### PR DESCRIPTION
## Description

- The e2e version matrix now resolves Grafana `13.1.1`, whose UI DOM changed and broke `queryEditor.spec.ts` locators (unrelated to any plugin change).
- Scope Select locators to the wrapper `div#..._select` — the `id` prop now also lands on the inner `<input>`, so `#..._select` matched two elements (strict-mode violation).
- Target the order-by DESC radio via its stable `name` attribute — `RadioButtonGroup` now auto-generates the input `id` and moves the group `id` to `name`.

Verified locally against Grafana `13.1.1` and `12.3.9`; backward-compatible with all supported versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)